### PR TITLE
Rework types to be tagged unions

### DIFF
--- a/src/backend_c.rs
+++ b/src/backend_c.rs
@@ -1,27 +1,48 @@
+use std::fmt::{self, Write, Display};
 use crate::ir::BackendC;
 
-use crate::lexer::Location;
 use crate::ast::*;
 use crate::ir::*;
+use crate::gen::Compiletime;
+use crate::lexer::Location;
 
-impl BackendC for TempValue {
-    fn dump(&self) -> String {
-        format!("__stack_{}", self.tag)
-    }
-}
-
-impl BackendC for Block {
-    fn dump(&self) -> String {
-        let mut stmts = String::new();
-        for stmt in &self.stmts {
-            stmts.push_str(&format!("{}", stmt.dump()));
+impl TempValue {
+    fn dump_c<'a>(&'a self, comptime: &'a Compiletime) -> impl Display + 'a {
+        struct Helper<'a>(&'a TempValue, &'a Compiletime);
+        impl<'a> Display for Helper<'a> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "__stack_{}", self.0.tag)
+            }
         }
-        stmts
+        Helper(self, comptime)
     }
 }
 
-impl BackendC for Statement {
-    fn dump(&self) -> String {
-        todo!()
+impl Block {
+    fn dump_c<'a>(&'a self, comptime: &'a Compiletime) -> impl Display + 'a {
+        struct Helper<'a>(&'a Block, &'a Compiletime);
+        impl<'a> Display for Helper<'a> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                // TODO: Value dump_c not implemented yet
+                // writeln!(f, "{}", self.0.name.dump_c(self.1))?;
+                for stmt in &self.0.stmts {
+                    write!(f, "{}", stmt.dump_c(self.1))?;
+                }
+                Ok(())
+            }
+        }
+        Helper(self, comptime)
+    }
+}
+
+impl Statement {
+    fn dump_c<'a>(&'a self, comptime: &'a Compiletime) -> impl Display + 'a {
+        struct Helper<'a>(&'a Statement, &'a Compiletime);
+        impl<'a> Display for Helper<'a> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                todo!()
+            }
+        }
+        Helper(self, comptime)
     }
 }

--- a/src/backend_qbe.rs
+++ b/src/backend_qbe.rs
@@ -1,228 +1,291 @@
-use std::fmt;
+use std::fmt::{self, Write, Display};
 
-use crate::lexer::Location;
 use crate::ast::*;
-use crate::ir::*;
 use crate::const_eval::ConstExpr;
+use crate::ir::*;
+use crate::gen::Compiletime;
+use crate::lexer::Location;
 
-impl fmt::Display for TempValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.tag)
-    }
-}
-
-impl fmt::Display for Block {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "{}", self.name)?;
-        for stmt in &self.stmts {
-            write!(f, "{stmt}")?;
-        }
-        Ok(())
-    }
-}
-
-impl fmt::Display for TopLevel {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            TopLevel::Type => todo!(),
-            TopLevel::Data => todo!(),
-            TopLevel::Function(name, params, ret_type, blocks, is_main) => {
-                let qbe_return_type = match ret_type {
-                    Some(ref typ) => typ.qbe_ext_type(),
-                    None => if *is_main { "w" } else { "" },
-                };
-                write!(f, "export function {qbe_return_type} ${name}(")?;
-
-                let mut param_count = 0;
-                write!(f, "{}", (params
-                                 .iter()
-                                 .map(|Param(tag, typ)| {
-                                     let f = format!("{} %.{param_count}", typ.qbe_ext_type());
-                                     param_count += 1;
-                                     f
-                                 })
-                                 .collect::<Vec<String>>()
-                                 .join(", "))
-                )?;
-
-                writeln!(f, ") {{");
-
-                for block in blocks {
-                    write!(f, "{block}")?;
-                }
-
-                writeln!(f, "}}");
-                Ok(())
-            },
-        }
-    }
-}
-
-impl fmt::Display for Statement {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Statement::Assignment(tv, instr) => {
-                let typ = if matches!(instr, Instruction::Call(..)) {
-                    tv.typ.qbe_abi_type()
-                } else {
-                    tv.typ.qbe_type()
-                };
-                writeln!(f, "{} ={} {instr}", Value::Temp(tv.clone()), typ)
+impl TempValue {
+    pub fn dump_qbe<'a>(&'a self, comptime: &'a Compiletime) -> impl Display + 'a {
+        struct Helper<'a>(&'a TempValue, &'a Compiletime);
+        impl<'a> Display for Helper<'a> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "{}", self.0.tag)
             }
-            Statement::Discard(instr) => writeln!(f, "{instr}"),
-            Statement::Raw(text) => writeln!(f, "{text}"),
         }
+        Helper(self, comptime)
     }
 }
 
-impl fmt::Display for Value {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Value::Global(name) => write!(f, "${name}"),
-            Value::Constant(name) => write!(f, "{name}"),
-            Value::Temp(tv) => write!(f, "%.{tv}"),
-            Value::Label(name) => write!(f, "@{name}"),
+impl Block {
+    pub fn dump_qbe<'a>(&'a self, comptime: &'a Compiletime) -> impl Display + 'a {
+        struct Helper<'a>(&'a Block, &'a Compiletime);
+        impl<'a> Display for Helper<'a> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                writeln!(f, "{}", self.0.name.dump_qbe(self.1))?;
+                for stmt in &self.0.stmts {
+                    write!(f, "{}", stmt.dump_qbe(self.1))?;
+                }
+                Ok(())
+            }
         }
+        Helper(self, comptime)
     }
 }
 
-impl fmt::Display for Instruction {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Instruction::Ret(opt) => {
-                match opt {
-                    Some(v) => write!(f, "ret {v}"),
-                    None => write!(f, "ret"),
-                }
-            },
-            Instruction::Copy(v) => {
-                write!(f, "copy {v}")
-            },
-            Instruction::Add(v1, v2) => {
-                write!(f, "add {v1}, {v2}")
-            },
-            Instruction::Sub(v1, v2) => {
-                write!(f, "sub {v1}, {v2}")
-            },
-            Instruction::Mul(v1, v2) => {
-                write!(f, "mul {v1}, {v2}")
-            },
-            Instruction::Div(v1, v2) => {
-                write!(f, "div {v1}, {v2}")
-            },
-            Instruction::DivU(v1, v2) => {
-                write!(f, "udiv {v1}, {v2}")
-            },
-            Instruction::Call(v, temps) => {
-                // TODO: variadics
-                write!(f, "call {v}(")?;
-                write!(f, "{}", (temps
-                                  .iter()
-                                  .map(|TempValue{tag, typ, ..}| {
-                                      let qtype = typ.qbe_ext_type();
-                                      format!("{qtype} %.{tag}")
-                                  })
-                                  .collect::<Vec<String>>()
-                                  .join(", ")
-                ))?;
-                write!(f, ")")
-            },
-            Instruction::Load(v_ptr, typ) => {
-                let qtype = typ.qbe_type();
-                if typ.is_struct() {
-                    match typ.struct_kind {
-                        StructKind::Array | StructKind::Slice => {
-                            write!(f, "copy {v_ptr}")
-                        },
-                        _ => todo!(),
-                    }
-                } else {
-                    if typ.sizeof() == 8 || typ.sizeof() == 4 {
-                        write!(f, "load{qtype} {v_ptr}")
-                    } else {
-                        let ext = typ.qbe_ext_type();
-                        write!(f, "load{ext} {v_ptr}")
-                    }
-                }
-            },
-            Instruction::Store(v_ptr, v, typ) => {
-                if typ.is_struct() {
-                    match typ.struct_kind {
-                        StructKind::Array => {
-                            let Some(ref inner) = typ.inner else { unreachable!() };
-                            let constexpr = typ.elements.const_resolve();
-                            let ConstExpr::Number(n) = constexpr else { unreachable!("user land error") };
-                            let bytes = n as usize * inner.sizeof();
-                            write!(f, "blit {v}, {v_ptr}, {bytes}")
-                        },
-                        StructKind::Slice => {
-                            let bytes = typ.sizeof();
-                            write!(f, "blit {v}, {v_ptr}, {bytes}")
-                        },
-                        _ => todo!(),
-                    }
-                } else {
-                    let qtype = typ.qbe_type();
-                    write!(f, "store{qtype} {v}, {v_ptr}")
-                }
-            },
-            Instruction::Alloc(typ) => {
-                // TODO: get alignment per type
-                write!(f, "alloc8 {}", typ.sizeof())
-            },
-            Instruction::Jmp(v) => {
-                write!(f, "jmp {v}")
-            },
-            Instruction::Jnz(v_test, v_true, v_false) => {
-                write!(f, "jnz {v_test}, {v_true}, {v_false}")
-            },
-            Instruction::Cmp(op, typ, v1, v2) => {
-                let instr = match op {
-                    Op::Gt => "gt",
-                    Op::Lt => "lt",
-                    Op::Ge => "ge",
-                    Op::Le => "le",
-                    Op::EqEq => "eq",
-                    Op::NotEq => "ne",
-                    _ => unreachable!(),
-                };
-                let qtyp = typ.qbe_type();
-                if op.qbe_depends_sign() {
-                    if typ.unsigned() {
-                        write!(f, "cu{instr}{qtyp} {v1}, {v2}")
-                    } else {
-                        write!(f, "cs{instr}{qtyp} {v1}, {v2}")
-                    }
-                } else {
-                    write!(f, "c{instr}{qtyp} {v1}, {v2}")
-                }
-            },
-            Instruction::Cast(v, as_typ, from_typ) => {
-                if as_typ.assert_number(ldef!()).is_ok() && from_typ.assert_number(ldef!()).is_ok() {
-                    match from_typ.kind {
-                        TypeKind::U64 | TypeKind::S64 => write!(f, "copy {v}"),
-                        TypeKind::U32 | TypeKind::S32 => {
-                            let s = if from_typ.unsigned() { "u" } else { "s" };
-                            if as_typ.sizeof() > from_typ.sizeof() {
-                                write!(f, "ext{s}w {v}")
-                            } else {
-                                write!(f, "copy {v}")
+impl TopLevel {
+    pub fn dump_qbe<'a>(&'a self, comptime: &'a Compiletime) -> impl Display + 'a {
+        struct Helper<'a>(&'a TopLevel, &'a Compiletime);
+        impl<'a> Display for Helper<'a> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                match self.0 {
+                    TopLevel::Type => todo!(),
+                    TopLevel::Data => todo!(),
+                    TopLevel::Function(name, params, ret_type, blocks, is_main) => {
+                        let qbe_return_type = match ret_type {
+                            Some(ref typ) => typ.qbe_ext_type(),
+                            None => {
+                                if *is_main {
+                                    "w"
+                                } else {
+                                    ""
+                                }
                             }
-                        },
-                        TypeKind::U16 | TypeKind::S16 => {
-                            let s = if from_typ.unsigned() { "u" } else { "s" };
-                            write!(f, "ext{s}h {v}")
-                        },
-                        TypeKind::U8 | TypeKind::S8 => {
-                            let s = if from_typ.unsigned() { "u" } else { "s" };
-                            write!(f, "ext{s}b {v}")
-                        },
-                        _ => unreachable!()
+                        };
+                        write!(f, "export function {qbe_return_type} ${name}(")?;
+                        
+                        let mut param_count = 0;
+                        write!(
+                            f,
+                            "{}",
+                            (params
+                             .iter()
+                             .map(|Param(tag, typ)| {
+                                 let f = format!("{} %.{param_count}", typ.qbe_ext_type());
+                                 param_count += 1;
+                                 f
+                             })
+                             .collect::<Vec<String>>()
+                             .join(", "))
+                        )?;
+                        
+                        writeln!(f, ") {{");
+                        
+                        for block in blocks {
+                            write!(f, "{}", block.dump_qbe(self.1))?;
+                        }
+                        
+                        writeln!(f, "}}");
+                        Ok(())
                     }
-                } else {
-                    todo!("unsupported conversion")
                 }
-            },
+            }
         }
+        Helper(self, comptime)
+    }
+}
+
+impl Statement {
+    pub fn dump_qbe<'a>(&'a self, comptime: &'a Compiletime) -> impl Display + 'a {
+        struct Helper<'a>(&'a Statement, &'a Compiletime);
+        impl<'a> Display for Helper<'a> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                match self.0 {
+                    Statement::Assignment(tv, instr) => {
+                        let typ = if matches!(instr, Instruction::Call(..)) {
+                            tv.typ.qbe_abi_type()
+                        } else {
+                            tv.typ.qbe_type()
+                        };
+                        writeln!(f, "{} ={} {}", Value::Temp(tv.clone()).dump_qbe(self.1), typ, instr.dump_qbe(self.1))
+                    }
+                    Statement::Discard(instr) => writeln!(f, "{}", instr.dump_qbe(self.1)),
+                    Statement::Raw(text) => writeln!(f, "{text}"),
+                }
+            }
+        }
+        Helper(self, comptime)
+    }
+}
+
+impl Value {
+    pub fn dump_qbe<'a>(&'a self, comptime: &'a Compiletime) -> impl Display + 'a {
+        struct Helper<'a>(&'a Value, &'a Compiletime);
+        impl<'a> Display for Helper<'a> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                match self.0 {
+                    Value::Global(name) => write!(f, "${name}"),
+                    Value::Constant(name) => write!(f, "{name}"),
+                    Value::Temp(tv) => write!(f, "%.{}", tv.dump_qbe(self.1)),
+                    Value::Label(name) => write!(f, "@{name}"),
+                }
+            }
+        }
+        Helper(self, comptime)
+    }
+}
+
+impl Instruction {
+    pub fn dump_qbe<'a>(&'a self, comptime: &'a Compiletime) -> impl Display + 'a {
+        struct Helper<'a>(&'a Instruction, &'a Compiletime);
+        impl<'a> Display for Helper<'a> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                match self.0 {
+                    Instruction::Ret(opt) => match opt {
+                        Some(v) => write!(f, "ret {}", v.dump_qbe(self.1)),
+                        None => write!(f, "ret"),
+                    },
+                    Instruction::Copy(v) => {
+                        write!(f, "copy {}", v.dump_qbe(self.1))
+                    }
+                    Instruction::Add(v1, v2) => {
+                        write!(f, "add {}, {}", v1.dump_qbe(self.1), v2.dump_qbe(self.1))
+                    }
+                    Instruction::Sub(v1, v2) => {
+                        write!(f, "sub {}, {}", v1.dump_qbe(self.1), v2.dump_qbe(self.1))
+                    }
+                    Instruction::Mul(v1, v2) => {
+                        write!(f, "mul {}, {}", v1.dump_qbe(self.1), v2.dump_qbe(self.1))
+                    }
+                    Instruction::Div(v1, v2) => {
+                        write!(f, "div {}, {}", v1.dump_qbe(self.1), v2.dump_qbe(self.1))
+                    }
+                    Instruction::DivU(v1, v2) => {
+                        write!(f, "udiv {}, {}", v1.dump_qbe(self.1), v2.dump_qbe(self.1))
+                    }
+                    Instruction::Call(v, temps) => {
+                        // TODO: variadics
+                        write!(f, "call {}(", v.dump_qbe(self.1))?;
+                        write!(
+                            f,
+                            "{}",
+                            (temps
+                             .iter()
+                             .map(|TempValue { tag, typ, .. }| {
+                                 let qtype = typ.qbe_ext_type();
+                                 format!("{qtype} %.{tag}")
+                             })
+                             .collect::<Vec<String>>()
+                             .join(", "))
+                        )?;
+                        write!(f, ")")
+                    }
+                    Instruction::Load(v_ptr, ptr_typ) => {
+                        let typ = ptr_typ.deref(self.1);
+                        let qtype = typ.qbe_type();
+                        if typ.is_struct() {
+                            match typ {
+                                Type::Array(..) | Type::Slice(..) => {
+                                    write!(f, "copy {}", v_ptr.dump_qbe(self.1))
+                                }
+                                _ => todo!(),
+                            }
+                        } else {
+                            if typ.sizeof(self.1) == 8 || typ.sizeof(self.1) == 4 {
+                                write!(f, "load{qtype} {}", v_ptr.dump_qbe(self.1))
+                            } else {
+                                let ext = typ.qbe_ext_type();
+                                write!(f, "load{ext} {}", v_ptr.dump_qbe(self.1))
+                            }
+                        }
+                    }
+                    Instruction::Store(v_ptr, v, typ) => {
+                        if typ.is_struct() {
+                            match typ {
+                                Type::Array(lazyexpr, typeid) => {
+                                    let inner = self.1.fetch_type(*typeid).unwrap();
+                                    let constexpr = lazyexpr.const_resolve();
+                                    let ConstExpr::Number(n) = constexpr else {
+                                        unreachable!("user land error")
+                                    };
+                                    let bytes = n as usize * inner.sizeof(self.1);
+                                    write!(f, "blit {}, {}, {bytes}", v.dump_qbe(self.1), v_ptr.dump_qbe(self.1))
+                                }
+                                Type::Slice(..) => {
+                                    let bytes = typ.sizeof(self.1);
+                                    write!(f, "blit {}, {}, {bytes}", v.dump_qbe(self.1), v_ptr.dump_qbe(self.1))
+                                }
+                                _ => todo!(),
+                            }
+                        } else {
+                            let qtype = typ.qbe_type();
+                            write!(f, "store{qtype} {}, {}", v.dump_qbe(self.1), v_ptr.dump_qbe(self.1))
+                        }
+                    }
+                    Instruction::Alloc(typ) => {
+                        // TODO: get alignment per type
+                        write!(f, "alloc8 {}", typ.sizeof(self.1))
+                    }
+                    Instruction::Jmp(v) => {
+                        write!(f, "jmp {}", v.dump_qbe(self.1))
+                    }
+                    Instruction::Jnz(v_test, v_true, v_false) => {
+                        write!(f, "jnz {}, {}, {}",
+                               v_test.dump_qbe(self.1),
+                               v_true.dump_qbe(self.1),
+                               v_false.dump_qbe(self.1)
+                        )
+                    }
+                    Instruction::Cmp(op, typ, v1, v2) => {
+                        let instr = match op {
+                            Op::Gt => "gt",
+                            Op::Lt => "lt",
+                            Op::Ge => "ge",
+                            Op::Le => "le",
+                            Op::EqEq => "eq",
+                            Op::NotEq => "ne",
+                            _ => unreachable!(),
+                        };
+                        let qtyp = typ.qbe_type();
+                        if op.qbe_depends_sign() {
+                            if typ.unsigned() {
+                                write!(f, "cu{instr}{qtyp} {}, {}",
+                                       v1.dump_qbe(self.1),
+                                       v2.dump_qbe(self.1),
+                                )
+                            } else {
+                                write!(f, "cs{instr}{qtyp} {}, {}",
+                                       v1.dump_qbe(self.1),
+                                       v2.dump_qbe(self.1),
+                                )
+                            }
+                        } else {
+                            write!(f, "c{instr}{qtyp} {}, {}",
+                                   v1.dump_qbe(self.1),
+                                   v2.dump_qbe(self.1),
+                            )
+                        }
+                    }
+                    Instruction::Cast(v, as_typ, from_typ) => {
+                        if as_typ.assert_number(ldef!()).is_ok() && from_typ.assert_number(ldef!()).is_ok() {
+                            match from_typ {
+                                Type::U64 | Type::S64 => write!(f, "copy {}", v.dump_qbe(self.1)),
+                                Type::U32 | Type::S32 => {
+                                    let s = if from_typ.unsigned() { "u" } else { "s" };
+                                    if as_typ.sizeof(self.1) > from_typ.sizeof(self.1) {
+                                        write!(f, "ext{s}w {}", v.dump_qbe(self.1))
+                                    } else {
+                                        write!(f, "copy {}", v.dump_qbe(self.1))
+                                    }
+                                }
+                                Type::U16 | Type::S16 => {
+                                    let s = if from_typ.unsigned() { "u" } else { "s" };
+                                    write!(f, "ext{s}h {}", v.dump_qbe(self.1))
+                                }
+                                Type::U8 | Type::S8 => {
+                                    let s = if from_typ.unsigned() { "u" } else { "s" };
+                                    write!(f, "ext{s}b {}", v.dump_qbe(self.1))
+                                }
+                                _ => unreachable!(),
+                            }
+                        } else {
+                            todo!("unsupported conversion")
+                        }
+                    }
+                }
+            }
+        }
+        Helper(self, comptime)
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,5 @@
-use std::fmt;
 use crate::lexer::Location;
+use std::fmt;
 
 #[derive(Debug)]
 pub struct SyntaxError {
@@ -9,9 +9,7 @@ pub struct SyntaxError {
 
 impl SyntaxError {
     pub fn new(location: Option<Location>, message: String) -> Self {
-        SyntaxError {
-            location, message
-        }
+        SyntaxError { location, message }
     }
 }
 
@@ -20,7 +18,7 @@ impl SyntaxError {
 //         SyntaxError::new(self.to_string())
 //     }
 // }
-// 
+//
 // impl Into<SyntaxError> for String {
 //     fn into(self) -> SyntaxError {
 //         SyntaxError::new(self)

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -1,19 +1,19 @@
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
 use std::fs::File;
-use std::process::Command;
 use std::io::Write as IoWrite;
+use std::process::Command;
 
-use crate::BuildOptions;
-use crate::lexer::{Token, Location};
-use crate::parser::Result;
 use crate::ast::*;
+use crate::const_eval::{ConstExpr, LazyExpr};
+use crate::constants::MODULE_SEPARATOR;
 use crate::decorator::DecoratedModule;
 use crate::errors::SyntaxError;
 use crate::ir::*;
-use crate::constants::MODULE_SEPARATOR;
-use crate::const_eval::{ConstExpr, LazyExpr};
-use crate::{Backend, SUFFIX_QBE, SUFFIX_LLVM, SUFFIX_C};
+use crate::lexer::{Location, Token};
+use crate::parser::Result;
+use crate::BuildOptions;
+use crate::{Backend, SUFFIX_C, SUFFIX_LLVM, SUFFIX_QBE};
 
 type Module = HashMap<String, FunctionDecl>;
 type SymbolTable = HashMap<String, TempValue>;
@@ -59,14 +59,14 @@ macro_rules! load (
 
 // Doesn't own any
 macro_rules! array_offset (
-    ($gen:expr, $tv:expr, $typ:expr, $i:expr) => {
+    ($comptime:expr, $gen:expr, $tv:expr, $typ:expr, $i:expr) => {
         {
             let btag = $gen.ctx.alloc();
             let ptr = $gen.ctx.alloc();
-            let bytes = $i as usize * $typ.sizeof();
+            let bytes = $i as usize * $typ.sizeof($comptime);
 
-            let btv = $gen.block_add_assign(temp![btag, TypeKind::U64.into()], Instruction::Copy(Value::Constant(format!("{bytes}"))));
-            let ptv = $gen.block_add_assign(temp![ptr, $typ.ptr()], Instruction::Add(Value::Temp($tv.clone()), Value::Temp(btv)));
+            let btv = $gen.block_add_assign(temp![btag, Type::U64], Instruction::Copy(Value::Constant(format!("{bytes}"))));
+            let ptv = $gen.block_add_assign(temp![ptr, $typ.ptr($comptime)], Instruction::Add(Value::Temp($tv.clone()), Value::Temp(btv)));
             ptv
         }
     }
@@ -86,7 +86,10 @@ impl StackFrame {
     }
 
     pub fn symtab_lookup(&mut self, name: &str, loc: Location) -> Result<TempValue> {
-        self.var_table.get(name).cloned().ok_or(error!(loc, "No variable exists of name '{name}'"))
+        self.var_table
+            .get(name)
+            .cloned()
+            .ok_or(error!(loc, "No variable exists of name '{name}'"))
     }
 
     pub fn constab_store(&mut self, name: String, expr: Expr) {
@@ -94,7 +97,10 @@ impl StackFrame {
     }
 
     pub fn constab_lookup(&mut self, name: &str, loc: Location) -> Result<Expr> {
-        self.const_table.get(name).cloned().ok_or(error!(loc, "No constant exists of name '{name}'"))
+        self.const_table
+            .get(name)
+            .cloned()
+            .ok_or(error!(loc, "No constant exists of name '{name}'"))
     }
 }
 
@@ -180,14 +186,26 @@ impl FunctionContext {
 #[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
 pub struct FunctionDecl {
     name: String, //TODO: remove when not needed
-    pub params: Vec<Param>,
-    ret_type: Option<Type>,
+    // pub params: Vec<Param>,
+     pub params: Vec<AstParam>,
+    ret_type: Option<AstType>,
     pub extern_name: Option<String>,
 }
 
 impl FunctionDecl {
-    pub fn new(params: Vec<Param>, ret_type: Option<Type>, name: String, extern_name: Option<String>) -> Self {
-        Self { params, ret_type, name, extern_name }
+    pub fn new(
+        // params: Vec<Param>,
+        params: Vec<AstParam>,
+        ret_type: Option<AstType>,
+        name: String,
+        extern_name: Option<String>,
+    ) -> Self {
+        Self {
+            params,
+            ret_type,
+            name,
+            extern_name,
+        }
     }
 }
 
@@ -206,7 +224,7 @@ pub struct Generator {
     expected_return: Type,
     strings: Vec<String>,
     cstrings: Vec<String>,
-    
+
     // IR
     toplevels: Vec<TopLevel>,
     working_blocks: Vec<Block>,
@@ -220,18 +238,22 @@ pub fn path_to_string(expr: Expr) -> String {
             t.push_str(MODULE_SEPARATOR);
             t.push_str(&path_to_string(*box_expr));
             t
-        },
+        }
         _ => unreachable!(),
     }
 }
 
 fn get_module_name(s: String) -> String {
-    let Some(idx) = s.rfind(MODULE_SEPARATOR) else { unreachable!() };
+    let Some(idx) = s.rfind(MODULE_SEPARATOR) else {
+        unreachable!()
+    };
     s[..idx].to_string()
 }
 
 fn get_func_name(s: String) -> String {
-    let Some(i) = s.rfind(MODULE_SEPARATOR) else { unreachable!() };
+    let Some(i) = s.rfind(MODULE_SEPARATOR) else {
+        unreachable!()
+    };
     let idx = i + 2;
     s[idx..].to_string()
 }
@@ -241,31 +263,54 @@ macro_rules! gen_funcall_from_funcdef {
     ($slf:expr, $comptime:expr, $modname:expr, $def:expr, $text:expr, $args:expr, $loc:expr) => {
         if $def.is_some() {
             let def = $def.unwrap().clone();
+            let params = Self::astparams_to_params(&def.params, $comptime);
             let parlen = def.params.len();
-            
+
             let tag = $slf.ctx.alloc();
             let txt = $text;
-            let ret_type = def.ret_type.clone().unwrap_or(TypeKind::Void.into());
+            let ret_type = def.ret_type.clone().map(|at| at.as_type($comptime)).unwrap_or(Type::Void);
             //let qt = ret_type.qbe_abi_type();
 
             let arglen = $args.len();
             if arglen != parlen {
-                return Err(error!($loc, "Expected {parlen} arguments, got {arglen} instead."));
+                return Err(error!(
+                    $loc,
+                    "Expected {parlen} arguments, got {arglen} instead."
+                ));
             }
 
             // Generate expressions
             let mut stack_values = Vec::new();
             for (i, expr) in $args.drain(..).enumerate() {
-                stack_values.push($slf.emit_expr($comptime, expr, Some(def.params.get(i).unwrap().1.clone()))?);
+                let arg = def.params.get(i).unwrap().1.clone().as_type($comptime);
+                stack_values.push($slf.emit_expr(
+                    $comptime,
+                    expr,
+                    Some((arg, false)),
+                )?);
             }
 
             // Type check arguments
             for i in 0..stack_values.len() {
-                if def.params.get(i).unwrap().1.infer_elements {
-                    return Err(error!(def.params[i].0.loc(), "Inferring array sizes is not supported in function parameters!"));
+                // Kinda a hack but kinda not
+                if let AstType::Array(_, _, infer_elements) = def.params.get(i).unwrap().1 {
+                    if infer_elements {
+                        return Err(error!(
+                            def.params[i].0.loc(),
+                            "Inferring array sizes is not supported in function parameters!"
+                        ));
+                    }
                 }
-                if !stack_values[i].typ.soft_equals(&def.params.get(i).unwrap().1) {
-                    return Err(error!(def.params[i].0.loc(), "Parameter expected type {}, but got {} instead.", (def.params[i].1), (stack_values[i].typ)));
+                if !stack_values[i]
+                    .typ
+                    .check_coerce(&params.get(i).unwrap().1, $comptime)
+                {
+                    return Err(error!(
+                        def.params[i].0.loc(),
+                        "Parameter expected type {}, but got {} instead.",
+                        (def.params[i].1),
+                        (stack_values[i].typ.display($comptime))
+                    ));
                 }
             }
 
@@ -273,13 +318,13 @@ macro_rules! gen_funcall_from_funcdef {
                 let extrn_name = def.extern_name.clone().unwrap();
                 let tv = $slf.block_add_assign(
                     temp![tag, ret_type],
-                    Instruction::Call(Value::Global(extrn_name), stack_values)
+                    Instruction::Call(Value::Global(extrn_name), stack_values),
                 );
                 Ok(tv)
             } else {
                 let tv = $slf.block_add_assign(
                     temp![tag, ret_type],
-                    Instruction::Call(Value::Global(format!("{}.{txt}", $modname)), stack_values)
+                    Instruction::Call(Value::Global(format!("{}.{txt}", $modname)), stack_values),
                 );
                 Ok(tv)
             }
@@ -287,7 +332,7 @@ macro_rules! gen_funcall_from_funcdef {
             let txt = $text;
             return Err(error!($loc, "Could not find function '{txt}'"));
         }
-    }
+    };
 }
 
 impl Generator {
@@ -299,7 +344,7 @@ impl Generator {
             ctx: FunctionContext::default(),
             expected_type: None,
             imports: HashSet::new(),
-            expected_return: TypeKind::Void.into(),
+            expected_return: Type::Void,
             strings: Vec::new(),
             cstrings: Vec::new(),
             toplevels: Vec::new(),
@@ -308,21 +353,21 @@ impl Generator {
         gen.generated_mod.name = name;
         gen
     }
-        
+
     // Dump after all AST converted to IR
-    fn dump(&mut self, backend: Backend) {
+    fn dump(&mut self, backend: Backend, comptime: &Compiletime) {
         match backend {
             Backend::Qbe => {
                 for toplevel in &self.toplevels {
-                    genf!(self, "{toplevel}");
+                    genf!(self, "{}", (toplevel.dump_qbe(comptime)));
                 }
-            },
+            }
             Backend::Llvm => {
                 todo!("LLVM ir dumping")
-            },
+            }
             Backend::C => {
                 todo!("C ir dumping")
-            },
+            }
         }
     }
 
@@ -342,15 +387,25 @@ impl Generator {
         let _ = self.ctx.frames.pop();
     }
 
-    fn import_lookup<'a>(&mut self, comptime: &'a mut Compiletime, modname: &str) -> Option<&'a Module> {
+    fn import_lookup<'a>(
+        &mut self,
+        comptime: &'a mut Compiletime,
+        modname: &str,
+    ) -> Option<&'a Module> {
         // No-op except for ? operator
         let imported_name = self.imports.get(modname)?;
         comptime.module_map.get(modname)
     }
 
     // TODO: make more performant
-    fn import_lookup_fuzzy<'a>(&mut self, comptime: &'a Compiletime, modname: &str) -> Option<(&'a Module, String)> {
-        let mut matches = self.imports.iter()
+    fn import_lookup_fuzzy<'a>(
+        &mut self,
+        comptime: &'a Compiletime,
+        modname: &str,
+    ) -> Option<(&'a Module, String)> {
+        let mut matches = self
+            .imports
+            .iter()
             .filter(|imp| imp.ends_with(modname))
             .map(|imp| imp.clone())
             .collect::<Vec<String>>();
@@ -367,30 +422,36 @@ impl Generator {
         let name = &matches[0];
         Some((comptime.module_map.get(name)?, matches.remove(0)))
     }
-    
+
     fn start_block(&mut self, text: &str) {
         let name = Value::Label(text.to_string());
-        self.working_blocks.push(Block{name, stmts: Vec::new(), dead: false});
+        self.working_blocks.push(Block {
+            name,
+            stmts: Vec::new(),
+            dead: false,
+        });
     }
 
     fn current_block(&mut self) -> &mut Block {
         self.working_blocks.last_mut().unwrap()
     }
-    
+
     fn drain_blocks(&mut self) -> Vec<Block> {
         self.working_blocks.drain(..).collect()
     }
-    
+
     // Construct the temp value in tv, and then we give it back to you
     fn block_add_assign(&mut self, tv: TempValue, instr: Instruction) -> TempValue {
-        self.current_block().stmts.push(Statement::Assignment(tv.clone(), instr));
+        self.current_block()
+            .stmts
+            .push(Statement::Assignment(tv.clone(), instr));
         tv
     }
 
     fn block_add_discard(&mut self, instr: Instruction) {
         self.current_block().stmts.push(Statement::Discard(instr));
     }
-    
+
     fn block_add_raw(&mut self, text: String) {
         self.current_block().stmts.push(Statement::Raw(text));
     }
@@ -402,13 +463,16 @@ impl Generator {
         if !val.typ.is_struct() {
             unreachable!("Must be a structure if not a pointer");
         }
-        match val.typ.struct_kind {
-            StructKind::Array => val.tag,
-            StructKind::Slice => {
+        match val.typ {
+            Type::Array(..) => val.tag,
+            Type::Slice(..) => {
                 let tag = self.ctx.alloc();
-                let tv = self.block_add_assign(temp![tag, TypeKind::U64.into()], Instruction::Load(Value::Temp(val.clone()), TypeKind::U64.into()));
+                let tv = self.block_add_assign(
+                    temp![tag, Type::U64],
+                    Instruction::Load(Value::Temp(val.clone()), Type::U64),
+                );
                 tv.tag
-            },
+            }
             _ => unreachable!("unreachable unless if we support operator overloading"),
         }
     }
@@ -422,7 +486,7 @@ impl Generator {
         // TODO: use toplevels instead
         genf!(
             self,
-r#"
+            r#"
 function l $.slice.ptr(l %slc) {{
 @start
     %p =l loadl %slc
@@ -439,18 +503,29 @@ function l $.slice.len(l %slc) {{
         );
 
         let mut map = HashMap::new();
-        let ptr_typ: Type = Into::<Type>::into(TypeKind::Void).ptr();
-        map.insert("ptr".into(), FunctionDecl::new(vec![], Some(ptr_typ), "ptr".into(), None));
-        map.insert("len".into(), FunctionDecl::new(vec![], Some(TypeKind::U64.into()), "len".into(), None));
-        comptime.method_map.insert(Type::wrap(TypeKind::Void.into(), StructKind::Slice, LazyExpr::default(), false), map);
+        let ptr_typ = AstType::Ptr(Box::new(AstType::Base(Type::Void)));
+        map.insert(
+            "ptr".into(),
+            FunctionDecl::new(vec![], Some(ptr_typ), "ptr".into(), None),
+        );
+        map.insert(
+            "len".into(),
+            FunctionDecl::new(vec![], Some(AstType::Base(Type::U64)), "len".into(), None),
+        );
+        let void_id = comptime.fetch_typeid(&Type::Void);
+        comptime
+            .method_map
+            .insert(Type::Slice(void_id), map);
         Ok(())
     }
 
-    fn type_to_builtin_check(typ: &Type) -> Type {
+    // TODO: this is very finnicky, only useful for resolving slice methods.
+    // Perhaps make this more explicit?
+    fn type_to_builtin_check(typ: &Type, comptime: &mut Compiletime) -> Type {
         if typ.is_struct() {
-            match typ.struct_kind {
-                StructKind::Slice => Type::wrap(TypeKind::Void.into(), StructKind::Slice, LazyExpr::default(), false),
-                _ => typ.clone()
+            match typ {
+                Type::Slice(..) => Type::Slice(comptime.fetch_typeid(&Type::Void)),
+                _ => typ.clone(),
             }
         } else {
             return typ.clone();
@@ -478,7 +553,9 @@ function l $.slice.len(l %slc) {{
                 text = &text[2..];
             } else if text.starts_with("\\x") && text.len() >= 4 {
                 let mut it = text.chars().take(4);
-                let (Some('\\'), Some('x'), Some(a), Some(b)) = (it.next(), it.next(), it.next(), it.next()) else {
+                let (Some('\\'), Some('x'), Some(a), Some(b)) =
+                    (it.next(), it.next(), it.next(), it.next())
+                else {
                     unreachable!();
                 };
                 buf.push_str("\\x");
@@ -486,7 +563,11 @@ function l $.slice.len(l %slc) {{
                 buf.push(b);
                 text = &text[4..];
             } else {
-                buf.push(text.chars().nth(0).expect("We have characters if its not empty"));
+                buf.push(
+                    text.chars()
+                        .nth(0)
+                        .expect("We have characters if its not empty"),
+                );
                 text = &text[1..];
             }
             len += 1;
@@ -498,7 +579,7 @@ function l $.slice.len(l %slc) {{
         let mut c = 0;
         self.strings.reverse();
         while !self.strings.is_empty() {
-            let (string, len) = Generator::escape_string(&self.strings.pop().unwrap()); 
+            let (string, len) = Generator::escape_string(&self.strings.pop().unwrap());
             genf!(self, "data $.str.data{c} = {{ b \"{string}\" }}");
             genf!(self, "data $.str{c} = {{ l $.str.data{c}, l {} }}", len);
             c += 1;
@@ -509,12 +590,12 @@ function l $.slice.len(l %slc) {{
         let mut c = 0;
         self.cstrings.reverse();
         while !self.cstrings.is_empty() {
-            let (cstring, _) = Generator::escape_string(&self.cstrings.pop().unwrap()); 
+            let (cstring, _) = Generator::escape_string(&self.cstrings.pop().unwrap());
             genf!(self, "data $.cstr{c} = {{ b \"{cstring}\", b 0 }}");
             c += 1;
         }
     }
-    
+
     pub fn emit(&mut self, comptime: &mut Compiletime, options: &BuildOptions) -> Result<()> {
         genf!(self, "# QBE Start");
         genf!(self, "data $fmt_d = {{ b \"%d\\n\", b 0 }}");
@@ -540,26 +621,55 @@ function l $.slice.len(l %slc) {{
         self.emit_strings();
         self.emit_c_strings();
         genf!(self, "");
-        
-        self.dump(options.target.backend()); // Emit IR into the backend 
+
+        self.dump(options.target.backend(), comptime); // Emit IR into the backend
         Ok(())
     }
 
-    pub fn emit_global(&mut self, comptime: &mut Compiletime, global: Global) -> Result<Option<TopLevel>> {
+    fn astparams_to_params(astparams: &Vec<AstParam>, comptime: &mut Compiletime) -> Vec<Param> {
+        let mut vec = Vec::new();
+        for astparam in astparams {
+            let typ = astparam.1.clone().as_type(comptime);
+            vec.push(Param(astparam.0.clone(), typ));
+        }
+        vec
+    }
+
+    pub fn emit_global(
+        &mut self,
+        comptime: &mut Compiletime,
+        global: Global,
+    ) -> Result<Option<TopLevel>> {
         match global {
-            Global::Decl(name, expr) => {
-                match expr {
-                    Expr::Func(fn_, params, ret_type, stmts, returns, attrs) => {
-                        if !returns && ret_type.is_some() {
-                            return Err(error!(fn_.loc(), "This function does not always return, but should return {}", (ret_type.unwrap())));
-                        }
-                        let Token::Ident(_, text) = name.clone() else { unreachable!() };
-                        Ok(Some(self.emit_function(comptime, params, ret_type, name, stmts, attrs)?))
-                    },
-                    Expr::FuncDecl(fn_, params, ret_type, _) => {
-                        Ok(None)
-                    },
-                    _ => return Err(error!(name.loc(), "Only global functions are supported for now!")),
+            Global::Decl(name, expr) => match expr {
+                Expr::Func(fn_, astparams, ret_type, stmts, returns, attrs) => {
+                    if !returns && ret_type.is_some() {
+                        return Err(error!(
+                            fn_.loc(),
+                            "This function does not always return, but should return {}",
+                            (ret_type.unwrap())
+                        ));
+                    }
+                    let Token::Ident(_, text) = name.clone() else {
+                        unreachable!()
+                    };
+                    let params = Self::astparams_to_params(&astparams, comptime);
+                    let rt = ret_type.map(|at| at.as_type(comptime));
+                    Ok(Some(self.emit_function(
+                        comptime,
+                        params,
+                        rt,
+                        name,
+                        stmts,
+                        attrs,
+                    )?))
+                }
+                Expr::FuncDecl(fn_, params, ret_type, _) => Ok(None),
+                _ => {
+                    return Err(error!(
+                        name.loc(),
+                        "Only global functions are supported for now!"
+                    ))
                 }
             },
             Global::Import(expr) => {
@@ -571,22 +681,34 @@ function l $.slice.len(l %slc) {{
                 }
                 self.imports.insert(modname);
                 Ok(None)
-            },
-            g => Err(error_orphan!("Unknown global {g:?}"))
+            }
+            g => Err(error_orphan!("Unknown global {g:?}")),
         }
     }
 
-    pub fn emit_function(&mut self, comptime: &mut Compiletime, params: Vec<Param>, ret_type: Option<Type>, name: Token, mut stmts: Vec<Stmt>, attrs: Vec<Attribute>) -> Result<TopLevel> {
-        let Token::Ident(loc, text2) = name else { unreachable!() };
-        
+    pub fn emit_function(
+        &mut self,
+        comptime: &mut Compiletime,
+        params: Vec<Param>,
+        ret_type: Option<Type>,
+        name: Token,
+        mut stmts: Vec<Stmt>,
+        attrs: Vec<Attribute>,
+    ) -> Result<TopLevel> {
+        let Token::Ident(loc, text2) = name else {
+            unreachable!()
+        };
+
         // Resolve function attributes
         let mut extern_name = None;
         for attr in attrs {
             match attr {
                 Attribute::Extern(expr) => {
-                    let Expr::String(Token::String(_, text)) = expr else { unreachable!() };
+                    let Expr::String(Token::String(_, text)) = expr else {
+                        unreachable!()
+                    };
                     extern_name = Some(text);
-                },
+                }
                 _ => return Err(error_orphan!("Unsupported function attribute `{attr:?}`")),
             }
         }
@@ -596,9 +718,9 @@ function l $.slice.len(l %slc) {{
 
         self.expected_return = match ret_type {
             Some(ref typ) => typ.clone(),
-            None => TypeKind::Void.into(),
+            None => Type::Void,
         };
-        
+
         let setting_main = &text == "main";
         if setting_main {
             if comptime.main_defined {
@@ -609,44 +731,64 @@ function l $.slice.len(l %slc) {{
             for stmt in &mut stmts {
                 match stmt {
                     Stmt::Return(_, _, ref mut is_main, _) => *is_main = true,
-                    _ => ()
+                    _ => (),
                 }
             }
         }
-        
+
         // Reset function context
         self.ctx = FunctionContext::default();
 
         // Add all parameters to symbol table
         let mut prelude = StackFrame::default();
         for Param(token, typ) in &params {
-            let Token::Ident(_, text) = token else { unreachable!() };
+            let Token::Ident(_, text) = token else {
+                unreachable!()
+            };
             let tag = self.ctx.alloc();
             prelude.symtab_store(text.clone(), temp![tag, typ.clone()]);
         }
-        
+
         // TODO: IMPORTANT: Need to redo the return evaluation
-        
+
         // NOTE: this does not follow the return semantic, as we will always have a working "block"
         self.start_block("start");
-        if ret_type.is_none() { // TODO: double check hack
+        if ret_type.is_none() {
+            // TODO: double check hack
             stmts.push(Stmt::Return(ldef!(), None, setting_main, false));
         }
         self.emit_stmts(comptime, stmts, Some(prelude))?;
         if ret_type.is_some() { // TODO: double check hack
-            // genf!(self, "ret 0"); //TODO I guess we didn't need this? return needs to be analyzed badly
+             // genf!(self, "ret 0"); //TODO I guess we didn't need this? return needs to be analyzed badly
         }
 
         // Reset expected_return (TODO: see if this absolutely needs to be here)
-        self.expected_return = TypeKind::Void.into();
+        self.expected_return = Type::Void;
         if setting_main {
-            Ok(TopLevel::Function(text, params, ret_type, self.drain_blocks(), setting_main))
+            Ok(TopLevel::Function(
+                text,
+                params,
+                ret_type,
+                self.drain_blocks(),
+                setting_main,
+            ))
         } else {
-            Ok(TopLevel::Function(format!("{}.{text}", self.generated_mod.name), params, ret_type, self.drain_blocks(), setting_main))
+            Ok(TopLevel::Function(
+                format!("{}.{text}", self.generated_mod.name),
+                params,
+                ret_type,
+                self.drain_blocks(),
+                setting_main,
+            ))
         }
     }
 
-    pub fn emit_stmts(&mut self, comptime: &mut Compiletime, stmts: Vec<Stmt>, prelude: Option<StackFrame>) -> Result<()> {
+    pub fn emit_stmts(
+        &mut self,
+        comptime: &mut Compiletime,
+        stmts: Vec<Stmt>,
+        prelude: Option<StackFrame>,
+    ) -> Result<()> {
         match prelude {
             Some(frame) => self.ctx.frames.push(frame),
             None => self.push_frame(),
@@ -657,15 +799,17 @@ function l $.slice.len(l %slc) {{
             if let Stmt::Return(_, _, _, _) = stmt {
                 let mut copied = deferred.clone();
                 for stmt in copied.drain(..).rev() {
-                    if self.current_block().dead { // Reset if we have returned out of it
+                    if self.current_block().dead {
+                        // Reset if we have returned out of it
                         let s = self.ctx.stopper();
                         self.start_block(&format!("BLK{s}"));
                     }
                     self.emit_stmt(comptime, stmt, &mut none)?;
                 }
             }
-            let mut opt: Option<&mut Vec<Stmt>>  = Some(&mut deferred);
-            if self.current_block().dead { // Reset if we have returned out of it
+            let mut opt: Option<&mut Vec<Stmt>> = Some(&mut deferred);
+            if self.current_block().dead {
+                // Reset if we have returned out of it
                 let s = self.ctx.stopper();
                 self.start_block(&format!("BLK{s}"));
             }
@@ -676,102 +820,128 @@ function l $.slice.len(l %slc) {{
     }
 
     fn dbg_print_val(&mut self, comptime: &mut Compiletime, val: TempValue) -> Result<()> {
-        // todo!("Let the IR support raw qbe IR");
-        if val.typ.is_ptr() {
-            self.block_add_raw(format!("%.void =w call $printf(l $fmt_ptr, ..., l %.{})", val))
-        } else {
-            match val.typ.kind {
-                TypeKind::U64 | TypeKind::S64 => {
-                    self.block_add_raw(format!("%.void =w call $printf(l $fmt_ll, ..., l %.{})", val));
-                },
-                TypeKind::U32 | TypeKind::U16 | TypeKind::U8 |
-                TypeKind::S32 | TypeKind::S16 | TypeKind::S8 => {
-                    //let tag = self.extend_to_long(val.tag, &val.typ);
-                    // TODO: incorrect output
+        match val.typ {
+            Type::U64 | Type::S64 => {
+                self.block_add_raw(format!(
+                    "%.void =w call $printf(l $fmt_ll, ..., l %.{})",
+                    val.dump_qbe(comptime)
+                ));
+            }
+            Type::U32 | Type::U16 | Type::U8 | Type::S32 | Type::S16 | Type::S8 => {
+                let tag = self.ctx.alloc();
+                let tv = self.block_add_assign(
+                    temp![tag, Type::U64],
+                    Instruction::Cast(Value::Temp(val.clone()), Type::U64, val.typ.clone()),
+                );
+                self.block_add_raw(format!(
+                    "%.void =w call $printf(l $fmt_d, ..., w %.{})",
+                    tv.dump_qbe(comptime)
+                ));
+            }
+            Type::Bool => {
+                self.block_add_raw(format!(
+                    "%.void =w call $printf(l $fmt_bool, ..., w %.{})",
+                    val.dump_qbe(comptime)
+                ));
+            }
+            Type::Void => unreachable!(),
+            Type::Ptr(_) => {
+                self.block_add_raw(format!(
+                    "%.void =w call $printf(l $fmt_ptr, ..., l %.{})",
+                    val.dump_qbe(comptime)
+                ))
+            },
+            Type::Array(ref lazyexpr, ref typeid) => {
+                let inner = comptime.fetch_type(*typeid).expect("Invalid typeid").clone();
+
+                self.block_add_raw(format!("%.void =w call $printf(l $fmt_arr_start, ...)"));
+                let constexpr = lazyexpr.const_resolve();
+                let ConstExpr::Number(n) = constexpr else {
+                    unreachable!("user land error")
+                };
+                for i in 0..n {
+                    let ptr = array_offset!(comptime, self, val, inner, i);
                     let tag = self.ctx.alloc();
                     let tv = self.block_add_assign(
-                        temp![tag, TypeKind::U64.into()],
-                        Instruction::Cast(Value::Temp(val.clone()), TypeKind::U64.into(), val.typ.clone())
+                        temp![tag, inner.clone()],
+                        Instruction::Load(Value::Temp(ptr.clone()), ptr.typ.clone()),
                     );
-                    self.block_add_raw(format!("%.void =w call $printf(l $fmt_d, ..., w %.{})", tv));
-                },
-                TypeKind::Bool => {
-                    self.block_add_raw(format!("%.void =w call $printf(l $fmt_bool, ..., w %.{})", val));
-                },
-                TypeKind::Void => unreachable!(),
-                TypeKind::Unresolved => unreachable!(),
-                TypeKind::Structure => {
-                    match val.typ.struct_kind {
-                        StructKind::Array => {
-                            let Some(ref inner) = val.typ.inner else { unreachable!() };
+                    self.dbg_print_val(comptime, tv);
+                }
+                self.block_add_raw(format!("%.void =w call $printf(l $fmt_arr_end, ...)"));
+            }
+            Type::Slice(typeid) => {
+                let sz_offset = self.ctx.alloc();
+                let sz_ptr = self.ctx.alloc();
+                let sz_offset_tv = self.block_add_assign(
+                    temp![sz_offset, Type::U64],
+                    Instruction::Copy(Value::Constant("8".into())),
+                );
+                let sz_ptr_tv = self.block_add_assign(
+                    temp![sz_ptr, Type::U64],
+                    Instruction::Add(Value::Temp(val.clone()), Value::Temp(sz_offset_tv)),
+                );
 
-                            self.block_add_raw(format!("%.void =w call $printf(l $fmt_arr_start, ...)"));
-                            let constexpr = val.typ.elements.const_resolve();
-                            let ConstExpr::Number(n) = constexpr else { unreachable!("user land error") };
-                            for i in 0..n {
-                                let ptr = array_offset!(self, val, inner, i);
-                                let tag = self.ctx.alloc();
-                                let tv = self.block_add_assign(
-                                    temp![tag, *val.typ.inner.clone().unwrap()],
-                                    Instruction::Load(Value::Temp(ptr.clone()), ptr.typ.clone())
-                                );
-                                self.dbg_print_val(comptime, tv);
-                            }
-                            self.block_add_raw(format!("%.void =w call $printf(l $fmt_arr_end, ...)"));
-                        },
-                        StructKind::Slice => {
-                            let sz_offset = self.ctx.alloc();
-                            let sz_ptr = self.ctx.alloc();
-                            let sz_offset_tv = self.block_add_assign(
-                                temp![sz_offset, TypeKind::U64.into()],
-                                Instruction::Copy(Value::Constant("8".into()))
-                            );
-                            let sz_ptr_tv = self.block_add_assign(
-                                temp![sz_ptr, TypeKind::U64.into()],
-                                Instruction::Add(Value::Temp(val.clone()), Value::Temp(sz_offset_tv))
-                            );
-                            
-                            let sz_tv = load!(self, TypeKind::U64.into(), sz_ptr_tv);
-                            let ptr_tv = load!(self, TypeKind::U64.into(), val);
+                let sz_tv = load!(self, Type::U64, sz_ptr_tv);
+                let ptr_tv = load!(self, Type::U64, val);
 
-                            self.block_add_raw(format!("%.void =w call $printf(l $fmt_arr_start, ...)"));
-                            self.block_add_raw(format!("%.void =w call $printf(l $fmt_ptr, ..., l %.{})", ptr_tv));
-                            self.block_add_raw(format!("%.void =w call $printf(l $fmt_ll, ..., l %.{})", sz_tv));
-                            self.block_add_raw(format!("%.void =w call $printf(l $fmt_arr_end, ...)"));
-                        },
-                        _ => todo!("generic printing of structures")
-                    }
-                },
+                self.block_add_raw(format!("%.void =w call $printf(l $fmt_arr_start, ...)"));
+                self.block_add_raw(format!(
+                    "%.void =w call $printf(l $fmt_ptr, ..., l %.{})",
+                    ptr_tv.dump_qbe(comptime)
+                ));
+                self.block_add_raw(format!(
+                    "%.void =w call $printf(l $fmt_ll, ..., l %.{})",
+                    sz_tv.dump_qbe(comptime)
+                ));
+                self.block_add_raw(format!("%.void =w call $printf(l $fmt_arr_end, ...)"));
             }
         }
         Ok(())
     }
 
-    pub fn emit_stmt(&mut self, comptime: &mut Compiletime, stmt: Stmt, deferred: &mut Option<&mut Vec<Stmt>>) -> Result<()> {
+    pub fn emit_stmt(
+        &mut self,
+        comptime: &mut Compiletime,
+        stmt: Stmt,
+        deferred: &mut Option<&mut Vec<Stmt>>,
+    ) -> Result<()> {
         match stmt {
             Stmt::Dbg(expr) => {
                 let tv = self.emit_expr(comptime, expr, None)?;
                 self.dbg_print_val(comptime, tv);
                 Ok(())
-            },
-            Stmt::Let(name, typ, expr, is_constant) => {
-                let Token::Ident(loc, text) = name else { unreachable!() };
+            }
+            Stmt::Let(name, astype, expr, is_constant) => {
+                let infer_elements = if let Some(AstType::Array(_, _, ie)) = astype {
+                    ie
+                } else {
+                    false
+                };
+                let typ = astype.map(|at| at.as_type(comptime));
+                let Token::Ident(loc, text) = name else {
+                    unreachable!()
+                };
 
                 // Do we need to allocate this on the stack?
                 let mut allocate = false;
                 if self.decorated_mod.addressed_vars.contains(&text) {
                     allocate = true;
                 }
-                
-                let raw = self.emit_expr(comptime, expr.clone(), typ.clone())?;
+
+                let raw = self.emit_expr(comptime, expr.clone(), typ.clone().map(|e| (e, infer_elements)))?;
 
                 let mut tv = if allocate {
                     let tag = self.ctx.alloc();
                     let tv_ptr = self.block_add_assign(
-                        temp![tag, raw.typ.ptr()],
-                        Instruction::Alloc(raw.typ.clone())
+                        temp![tag, raw.typ.ptr(comptime)],
+                        Instruction::Alloc(raw.typ.clone()),
                     );
-                    self.block_add_discard(Instruction::Store(Value::Temp(tv_ptr.clone()), Value::Temp(raw.clone()), raw.typ.clone()));
+                    self.block_add_discard(Instruction::Store(
+                        Value::Temp(tv_ptr.clone()),
+                        Value::Temp(raw.clone()),
+                        raw.typ.clone(),
+                    ));
                     temp![tv_ptr.tag, raw.typ.clone()]
                 } else {
                     raw
@@ -780,14 +950,19 @@ function l $.slice.len(l %slc) {{
                 if let Some(mut expected_type) = typ {
                     expected_type = crate::const_eval::type_resolve(self, expected_type)?;
                     // TODO: refactor type checking
-                    if !tv.typ.soft_equals_array(&mut expected_type) {
-                        return Err(error!(loc, "Expected type {expected_type}, but got {} instead", (tv.typ)));
+                    if !tv.typ.check_coerce_array(&mut expected_type, infer_elements, comptime) {
+                        return Err(error!(loc, "Expected type {}, but got {} instead",
+                                          (expected_type.display(comptime)),
+                                          (tv.typ.display(comptime))));
                     }
                 }
 
                 let frame = self.current_frame()?;
                 if frame.symtab_lookup(&text, loc.clone()).is_ok() {
-                    return Err(error!(loc, "Redefinition of variable {text} is not allowed!"));
+                    return Err(error!(
+                        loc,
+                        "Redefinition of variable {text} is not allowed!"
+                    ));
                 }
                 if is_constant {
                     tv.constant = true;
@@ -795,19 +970,23 @@ function l $.slice.len(l %slc) {{
                 }
                 frame.symtab_store(text, tv);
                 Ok(())
-            },
+            }
             Stmt::Scope(stmts) => {
                 self.emit_stmts(comptime, stmts, None)?;
                 Ok(())
-            },
+            }
             Stmt::Ex(expr) => {
                 let _ = self.emit_expr(comptime, expr, None)?;
                 Ok(())
-            },
+            }
             Stmt::If(expr, box_stmt, opt_else) => {
                 let val = self.emit_expr(comptime, expr, None)?;
                 let i = self.ctx.label_cond();
-                self.block_add_discard(Instruction::Jnz(Value::Temp(val), label!["i{i}_body"], label!["i{i}_else"]));
+                self.block_add_discard(Instruction::Jnz(
+                    Value::Temp(val),
+                    label!["i{i}_body"],
+                    label!["i{i}_else"],
+                ));
                 self.start_block(&format!("i{i}_body"));
                 self.emit_stmt(comptime, *box_stmt, deferred)?;
                 self.block_add_discard(Instruction::Jmp(label!["i{i}_end"]));
@@ -818,26 +997,30 @@ function l $.slice.len(l %slc) {{
                 }
 
                 self.start_block(&format!("i{i}_end"));
-                
+
                 Ok(())
-            },
+            }
             Stmt::While(expr, box_stmt) => {
                 self.ctx.loop_push(); // Allow break/continue
-                
+
                 let p = self.ctx.label_loop();
                 self.start_block(&format!("p{p}_test"));
                 let val = self.emit_expr(comptime, expr, None)?;
-                self.block_add_discard(Instruction::Jnz(Value::Temp(val), label!["p{p}_body"], label!["p{p}_exit"]));
+                self.block_add_discard(Instruction::Jnz(
+                    Value::Temp(val),
+                    label!["p{p}_body"],
+                    label!["p{p}_exit"],
+                ));
 
                 self.start_block(&format!("p{p}_body"));
                 self.emit_stmt(comptime, *box_stmt, deferred)?;
                 self.block_add_discard(Instruction::Jmp(label!["p{p}_test"]));
-                
+
                 self.start_block(&format!("p{p}_exit"));
 
                 self.ctx.loop_pop(); // Disallow break/continue
                 Ok(())
-            },
+            }
             Stmt::Break(loc) => {
                 // Get the current block we are in
                 let p = self.ctx.current_loop();
@@ -849,7 +1032,7 @@ function l $.slice.len(l %slc) {{
                 let s = self.ctx.stopper();
                 self.start_block(&format!("p{p}_stopper{s}"));
                 Ok(())
-            },
+            }
             Stmt::Continue(loc) => {
                 // Get the current block we are in
                 let p = self.ctx.current_loop();
@@ -861,18 +1044,21 @@ function l $.slice.len(l %slc) {{
                 let s = self.ctx.stopper();
                 self.start_block(&format!("p{p}_stopper{s}"));
                 Ok(())
-            },
+            }
             Stmt::Return(loc, opt, setting_main, use_stopper) => {
                 if let Some(expr) = opt {
                     let tv = self.emit_expr(comptime, expr, None)?;
                     if self.expected_return != tv.typ {
-                        return Err(error!(loc, "Expected to return {}, but got {} instead", (self.expected_return), (tv.typ)));
+                        return Err(error!(loc, "Expected to return {}, but got {} instead",
+                                          (self.expected_return.display(comptime)),
+                                          (tv.typ.display(comptime))));
                     }
                     self.block_add_discard(Instruction::Ret(Some(Value::Temp(tv))));
                 } else {
-                    if self.expected_return != TypeKind::Void.into() {
-                        let void: Type = TypeKind::Void.into();
-                        return Err(error!(loc, "Expected to return {}, but got {} instead", (self.expected_return), (void)));
+                    if self.expected_return != Type::Void {
+                        return Err(error!(loc, "Expected to return {}, but got {} instead",
+                                          (self.expected_return.display(comptime)),
+                                          (Type::Void.display(comptime))));
                     }
                     // TODO: check HACK: stupid dumb dirty annoying hack ty qbe
                     if setting_main {
@@ -889,7 +1075,7 @@ function l $.slice.len(l %slc) {{
                 //     self.start_block(format!("return_stopper{s}"))
                 self.current_block().dead = true;
                 Ok(())
-            },
+            }
             Stmt::Defer(loc, box_stmt) => {
                 if let Some(stmts) = deferred {
                     stmts.push(*box_stmt);
@@ -897,15 +1083,22 @@ function l $.slice.len(l %slc) {{
                 } else {
                     Err(error!(loc, "Cannot defer here (did you try to nest them?)"))
                 }
-            },
+            }
             _ => todo!("stmt {stmt:?}"),
         }
     }
 
-    pub fn emit_expr(&mut self, comptime: &mut Compiletime, expr: Expr, expected_type: Option<Type>) -> Result<TempValue> {
+    pub fn emit_expr(
+        &mut self,
+        comptime: &mut Compiletime,
+        expr: Expr,
+        expected_type: Option<(Type, bool)>,
+    ) -> Result<TempValue> {
         match expr {
             Expr::Ident(token) => {
-                let Token::Ident(loc, text) = token else { unreachable!() };
+                let Token::Ident(loc, text) = token else {
+                    unreachable!()
+                };
 
                 let mut allocated = false;
                 if self.decorated_mod.addressed_vars.contains(&text) {
@@ -914,226 +1107,337 @@ function l $.slice.len(l %slc) {{
 
                 let tv = self.ctx.lookup(&text, loc)?;
                 if allocated {
-                    let deref = tv.typ.deref(); // TODO: does this make sense? why would the type be a ptr
+                    let deref = tv.typ.deref(comptime); // TODO: does this make sense? why would the type be a ptr
                     let tag = self.ctx.alloc();
                     let tv_retrieved = self.block_add_assign(
                         temp![tag, tv.typ.clone()],
-                        Instruction::Load(Value::Temp(tv), deref)
+                        Instruction::Load(Value::Temp(tv), deref),
                     );
                     Ok(tv_retrieved)
                 } else {
                     Ok(tv)
                 }
-            },
+            }
             Expr::Path(token, box_expr) => {
                 todo!()
-            },
+            }
             Expr::Bool(token) => {
                 let b = match token {
                     Token::True(_) => "1",
                     Token::False(_) => "0",
-                    _ => unreachable!()
+                    _ => unreachable!(),
                 };
 
                 let tag = self.ctx.alloc();
                 let tv = self.block_add_assign(
-                    temp![tag, TypeKind::Bool.into()],
-                    Instruction::Copy(Value::Constant(format!("{b}")))
+                    temp![tag, Type::Bool],
+                    Instruction::Copy(Value::Constant(format!("{b}"))),
                 );
                 Ok(tv)
-            },
+            }
             Expr::Number(token) => {
-                let Token::Int(_, i) = token else { unreachable!() };
+                let Token::Int(_, i) = token else {
+                    unreachable!()
+                };
 
-                let typ = if let Some(typ) = expected_type {
+                let typ = if let Some((typ, _)) = expected_type {
                     if typ.assert_number(ldef!()).is_ok() {
                         typ
                     } else {
-                        TypeKind::S32.into()
+                        Type::S32
                     }
                 } else {
-                    TypeKind::S32.into()
+                    Type::S32
                 };
 
                 let tag = self.ctx.alloc();
                 let tv = self.block_add_assign(
                     temp![tag, typ],
-                    Instruction::Copy(Value::Constant(format!("{i}")))
+                    Instruction::Copy(Value::Constant(format!("{i}"))),
                 );
                 Ok(tv)
-            },
+            }
             Expr::String(token) => {
-                let Token::String(_, text) = token else { unreachable!() };
+                let Token::String(_, text) = token else {
+                    unreachable!()
+                };
                 let gtag = self.strings.len();
                 let tag = self.ctx.alloc(); // for local instance
                 let tv = self.block_add_assign(
-                    temp![tag, TypeKind::U64.into()],
-                    Instruction::Copy(Value::Global(format!(".str{gtag}")))
+                    temp![tag, Type::U64],
+                    Instruction::Copy(Value::Global(format!(".str{gtag}"))),
                 );
                 self.strings.push(text);
-                Ok(temp![tv.tag, self.decorated_mod.parse_module.type_alias_map.get("str").unwrap().clone()])
-            },
+
+                let str_type = self
+                    .decorated_mod
+                    .parse_module
+                    .type_alias_map
+                    .get("str")
+                    .unwrap()
+                    .clone()
+                    .as_type(comptime);
+                Ok(temp![tv.tag, str_type])
+            }
             Expr::CString(token) => {
-                let Token::CString(_, text) = token else { unreachable!() };
+                let Token::CString(_, text) = token else {
+                    unreachable!()
+                };
                 let gtag = self.cstrings.len();
                 let tag = self.ctx.alloc(); // for local instance
                 let tv = self.block_add_assign(
-                    temp![tag, TypeKind::U64.into()],
-                    Instruction::Copy(Value::Global(format!(".cstr{gtag}")))
+                    temp![tag, Type::U64],
+                    Instruction::Copy(Value::Global(format!(".cstr{gtag}"))),
                 );
                 self.cstrings.push(text);
-                Ok(temp![tv.tag, self.decorated_mod.parse_module.type_alias_map.get("cstr").unwrap().clone()])
-            },
+
+                let cstr_type = self
+                    .decorated_mod
+                    .parse_module
+                    .type_alias_map
+                    .get("cstr")
+                    .unwrap()
+                    .clone()
+                    .as_type(comptime);
+                Ok(temp![tv.tag, cstr_type])
+            }
             Expr::BinOp(_, op, box_lhs, box_rhs) => {
                 match op {
                     Op::Add | Op::Sub | Op::Mul | Op::Div => {
                         let lloc = box_lhs.loc();
                         let rloc = box_rhs.loc();
-                        
+
                         let lval = self.emit_expr(comptime, *box_lhs, expected_type)?;
-                        let rval = self.emit_expr(comptime, *box_rhs, Some(lval.typ.clone()))?;
+                        let rval = self.emit_expr(comptime, *box_rhs, Some((lval.typ.clone(), false)))?;
                         lval.typ.assert_number(lloc)?;
                         rval.typ.assert_number(rloc)?;
-                        
+
                         let tag = self.ctx.alloc();
                         let typ = lval.typ.clone();
                         let _ = match op {
-                            Op::Add => self.block_add_assign(temp![tag, lval.typ.clone()], Instruction::Add(Value::Temp(lval), Value::Temp(rval))),
-                            Op::Sub => self.block_add_assign(temp![tag, lval.typ.clone()], Instruction::Sub(Value::Temp(lval), Value::Temp(rval))),
-                            Op::Mul => self.block_add_assign(temp![tag, lval.typ.clone()], Instruction::Mul(Value::Temp(lval), Value::Temp(rval))),
+                            Op::Add => self.block_add_assign(
+                                temp![tag, lval.typ.clone()],
+                                Instruction::Add(Value::Temp(lval), Value::Temp(rval)),
+                            ),
+                            Op::Sub => self.block_add_assign(
+                                temp![tag, lval.typ.clone()],
+                                Instruction::Sub(Value::Temp(lval), Value::Temp(rval)),
+                            ),
+                            Op::Mul => self.block_add_assign(
+                                temp![tag, lval.typ.clone()],
+                                Instruction::Mul(Value::Temp(lval), Value::Temp(rval)),
+                            ),
                             Op::Div => {
                                 if lval.typ.unsigned() {
-                                    self.block_add_assign(temp![tag, lval.typ.clone()], Instruction::DivU(Value::Temp(lval), Value::Temp(rval)))
+                                    self.block_add_assign(
+                                        temp![tag, lval.typ.clone()],
+                                        Instruction::DivU(Value::Temp(lval), Value::Temp(rval)),
+                                    )
                                 } else {
-                                    self.block_add_assign(temp![tag, lval.typ.clone()], Instruction::Div(Value::Temp(lval), Value::Temp(rval)))
+                                    self.block_add_assign(
+                                        temp![tag, lval.typ.clone()],
+                                        Instruction::Div(Value::Temp(lval), Value::Temp(rval)),
+                                    )
                                 }
-                            },
+                            }
                             _ => unreachable!(),
                         };
                         Ok(temp![tag, typ])
-                    },
+                    }
                     Op::Eq => {
                         match *box_lhs {
                             Expr::Ident(Token::Ident(loc, text)) => {
                                 // EQ => Assigning to a variable
                                 let val = self.ctx.lookup(&text, loc.clone())?;
 
-                                let new = self.emit_expr(comptime, *box_rhs, Some(val.typ.clone()))?;
+                                let new =
+                                    self.emit_expr(comptime, *box_rhs, Some((val.typ.clone(), false)))?;
                                 if val.typ != new.typ {
-                                    return Err(error!(loc, "Assignment expected {}, got {} instead", (val.typ), (new.typ)))
+                                    return Err(error!(loc, "Assignment expected {}, got {} instead",
+                                                      (val.typ.display(comptime)),
+                                                      (new.typ.display(comptime))))
                                 }
                                 if val.constant {
-                                    return Err(error!(loc, "Cannot assign to a constant!"))
+                                    return Err(error!(loc, "Cannot assign to a constant!"));
                                 }
-                                let _ = self.block_add_assign(temp![val.tag, new.typ.clone()], Instruction::Copy(Value::Temp(new.clone())));
+                                let _ = self.block_add_assign(
+                                    temp![val.tag, new.typ.clone()],
+                                    Instruction::Copy(Value::Temp(new.clone())),
+                                );
                                 Ok(new)
-                            },
+                            }
                             Expr::UnOp(t, Op::Mul, box_expr, postfix) => {
                                 // EQ => Assigning to a dereferenced variable
                                 let loc = t.loc();
                                 let ptr = self.emit_expr(comptime, *box_expr, None)?;
-                                
+
                                 if !ptr.typ.is_ptr() {
-                                    return Err(error!(loc, "Cannot dereference a non-pointer type {}", (ptr.typ)));
+                                    return Err(error!(
+                                        loc,
+                                        "Cannot dereference a non-pointer type {}",
+                                        (ptr.typ.display(comptime))
+                                    ));
                                 }
 
-                                let new = self.emit_expr(comptime, *box_rhs, Some(ptr.typ.deref()))?;
-                                
-                                let deref = ptr.typ.deref();
+                                let new = self.emit_expr(
+                                    comptime,
+                                    *box_rhs,
+                                    Some((ptr.typ.deref(comptime), false)),
+                                )?;
+
+                                let deref = ptr.typ.deref(comptime);
                                 let qtype = deref.qbe_type();
                                 // TODO: won't be compatible with large data
 
                                 // genf!(self, "store{qtype} %.s{}, %.s{}", (new.tag), (ptr.tag));
-                                self.block_add_discard(Instruction::Store(Value::Temp(ptr), Value::Temp(new.clone()), new.typ.clone()));
+                                self.block_add_discard(Instruction::Store(
+                                    Value::Temp(ptr),
+                                    Value::Temp(new.clone()),
+                                    new.typ.clone(),
+                                ));
                                 Ok(new)
-                            },
+                            }
                             Expr::BinOp(_, Op::Arr, box_lhs2, box_rhs2) => {
                                 // EQ => Assigning to an indexed variable
                                 let lloc = box_lhs2.loc();
                                 let rloc = box_rhs2.loc();
-                                
+
                                 let lval = self.emit_expr(comptime, *box_lhs2, None)?;
                                 let rval = self.emit_expr(comptime, *box_rhs2, None)?;
-                                lval.typ.assert_indexable(lloc)?;
+                                lval.typ.assert_indexable(lloc, comptime)?;
                                 rval.typ.assert_number(rloc)?;
                                 let base = self.get_indexable_ptr(&lval);
 
-                                let Some(ref inner) = lval.typ.inner else { unreachable!() };
+                                // TODO: abstract away getting "inner type"
+                                let Type::Array(_, typeid) = lval.typ else { unreachable!() };
+                                let inner = comptime.fetch_type(typeid).unwrap();
                                 let rtag = self.ctx.alloc();
                                 let rtv = self.block_add_assign(
-                                    temp![rtag, TypeKind::U64.into()],
-                                    Instruction::Cast(Value::Temp(rval.clone()), TypeKind::U64.into(), rval.typ.clone())
+                                    temp![rtag, Type::U64],
+                                    Instruction::Cast(
+                                        Value::Temp(rval.clone()),
+                                        Type::U64,
+                                        rval.typ.clone(),
+                                    ),
                                 );
                                 let bytes = self.ctx.alloc();
                                 let bytes_tv = self.block_add_assign(
-                                    temp![bytes, TypeKind::U64.into()],
-                                    Instruction::Mul(Value::Temp(rtv), Value::Constant(format!("{}", inner.sizeof())))
+                                    temp![bytes, Type::U64],
+                                    Instruction::Mul(
+                                        Value::Temp(rtv),
+                                        Value::Constant(format!("{}", inner.sizeof(comptime))),
+                                    ),
                                 );
                                 let ptr = self.ctx.alloc();
                                 let ptr_tv = self.block_add_assign(
-                                    temp![ptr, TypeKind::U64.into()],
-                                    Instruction::Add(Value::Temp(temp![base, TypeKind::U64.into()]), Value::Temp(bytes_tv))
+                                    temp![ptr, Type::U64],
+                                    Instruction::Add(
+                                        Value::Temp(temp![base, Type::U64]),
+                                        Value::Temp(bytes_tv),
+                                    ),
                                 );
 
-                                let val = self.emit_expr(comptime, *box_rhs, Some(*inner.clone()))?;
-                                self.block_add_discard(Instruction::Store(Value::Temp(ptr_tv), Value::Temp(val.clone()), val.typ.clone()));
+                                let val =
+                                    self.emit_expr(comptime, *box_rhs, Some((inner.clone(), false)))?;
+                                self.block_add_discard(Instruction::Store(
+                                    Value::Temp(ptr_tv),
+                                    Value::Temp(val.clone()),
+                                    val.typ.clone(),
+                                ));
                                 Ok(val)
-                            },
-                            e => return Err(error!(e.loc(), "Expected variable or deref assignment")),
+                            }
+                            e => {
+                                return Err(error!(
+                                    e.loc(),
+                                    "Expected variable or deref assignment"
+                                ))
+                            }
                         }
-                    },
+                    }
                     Op::AndAnd => {
                         let lloc = box_lhs.loc();
                         let rloc = box_rhs.loc();
-                        
-                        let lval = self.emit_expr(comptime, *box_lhs, Some(TypeKind::Bool.into()))?;
-                        let rval = self.emit_expr(comptime, *box_rhs, Some(TypeKind::Bool.into()))?;
+
+                        let lval =
+                            self.emit_expr(comptime, *box_lhs, Some((Type::Bool, false)))?;
+                        let rval =
+                            self.emit_expr(comptime, *box_rhs, Some((Type::Bool, false)))?;
                         lval.typ.assert_bool(lloc)?;
                         rval.typ.assert_bool(rloc)?;
 
                         let cond = self.ctx.alloc();
                         let tag = self.ctx.alloc();
                         let l = self.ctx.label_logic();
-                        self.block_add_discard(Instruction::Jnz(Value::Temp(lval), label!["l{l}_rhs"], label!["l{l}_false"]));
+                        self.block_add_discard(Instruction::Jnz(
+                            Value::Temp(lval),
+                            label!["l{l}_rhs"],
+                            label!["l{l}_false"],
+                        ));
                         self.start_block(&format!("l{l}_rhs"));
-                        self.block_add_discard(Instruction::Jnz(Value::Temp(rval), label!["l{l}_true"], label!["l{l}_false"]));
+                        self.block_add_discard(Instruction::Jnz(
+                            Value::Temp(rval),
+                            label!["l{l}_true"],
+                            label!["l{l}_false"],
+                        ));
 
                         self.start_block(&format!("l{l}_true"));
-                        let _ = self.block_add_assign(temp![tag, TypeKind::Bool.into()], Instruction::Copy(Value::Constant("1".into())));
+                        let _ = self.block_add_assign(
+                            temp![tag, Type::Bool],
+                            Instruction::Copy(Value::Constant("1".into())),
+                        );
                         self.block_add_discard(Instruction::Jmp(label!["l{l}_end"]));
 
                         self.start_block(&format!("l{l}_false"));
-                        let _ = self.block_add_assign(temp![tag, TypeKind::Bool.into()], Instruction::Copy(Value::Constant("0".into())));
+                        let _ = self.block_add_assign(
+                            temp![tag, Type::Bool],
+                            Instruction::Copy(Value::Constant("0".into())),
+                        );
 
                         self.start_block(&format!("l{l}_end"));
-                        Ok(temp![tag, TypeKind::Bool.into()])
-                    },
+                        Ok(temp![tag, Type::Bool])
+                    }
                     Op::OrOr => {
                         let lloc = box_lhs.loc();
                         let rloc = box_rhs.loc();
-                        
-                        let lval = self.emit_expr(comptime, *box_lhs, Some(TypeKind::Bool.into()))?;
-                        let rval = self.emit_expr(comptime, *box_rhs, Some(TypeKind::Bool.into()))?;
+
+                        let lval =
+                            self.emit_expr(comptime, *box_lhs, Some((Type::Bool, false)))?;
+                        let rval =
+                            self.emit_expr(comptime, *box_rhs, Some((Type::Bool, false)))?;
                         lval.typ.assert_bool(lloc)?;
                         rval.typ.assert_bool(rloc)?;
 
                         let cond = self.ctx.alloc();
                         let tag = self.ctx.alloc();
                         let l = self.ctx.label_logic();
-                        self.block_add_discard(Instruction::Jnz(Value::Temp(lval), label!["l{l}_true"], label!["l{l}_rhs"]));
+                        self.block_add_discard(Instruction::Jnz(
+                            Value::Temp(lval),
+                            label!["l{l}_true"],
+                            label!["l{l}_rhs"],
+                        ));
                         self.start_block(&format!("l{l}_rhs"));
-                        self.block_add_discard(Instruction::Jnz(Value::Temp(rval), label!["l{l}_true"], label!["l{l}_false"]));
+                        self.block_add_discard(Instruction::Jnz(
+                            Value::Temp(rval),
+                            label!["l{l}_true"],
+                            label!["l{l}_false"],
+                        ));
 
                         self.start_block(&format!("l{l}_true"));
-                        let _ = self.block_add_assign(temp![tag, TypeKind::Bool.into()], Instruction::Copy(Value::Constant("1".into())));
+                        let _ = self.block_add_assign(
+                            temp![tag, Type::Bool],
+                            Instruction::Copy(Value::Constant("1".into())),
+                        );
                         self.block_add_discard(Instruction::Jmp(label!["l{l}_end"]));
 
                         self.start_block(&format!("l{l}_false"));
-                        let _ = self.block_add_assign(temp![tag, TypeKind::Bool.into()], Instruction::Copy(Value::Constant("0".into())));
+                        let _ = self.block_add_assign(
+                            temp![tag, Type::Bool],
+                            Instruction::Copy(Value::Constant("0".into())),
+                        );
 
                         self.start_block(&format!("l{l}_end"));
-                        Ok(temp![tag, TypeKind::Bool.into()])
-                    },
+                        Ok(temp![tag, Type::Bool])
+                    }
                     Op::Gt | Op::Lt | Op::Ge | Op::Le | Op::EqEq | Op::NotEq => {
                         let lloc = box_lhs.loc();
                         let rloc = box_rhs.loc();
@@ -1141,67 +1445,83 @@ function l $.slice.len(l %slc) {{
                         // TODO: type checking bug
                         let lval = self.emit_expr(comptime, *box_lhs, expected_type)?;
                         lval.typ.assert_comparable(lloc)?;
-                        let rval = self.emit_expr(comptime, *box_rhs, Some(lval.typ.clone()))?;
+                        let rval = self.emit_expr(comptime, *box_rhs, Some((lval.typ.clone(), false)))?;
                         rval.typ.assert_comparable(rloc)?;
 
                         let tag = self.ctx.alloc();
                         let tv = self.block_add_assign(
-                            temp![tag, TypeKind::Bool.into()],
-                            Instruction::Cmp(op, lval.typ.clone(), Value::Temp(lval), Value::Temp(rval))
+                            temp![tag, Type::Bool],
+                            Instruction::Cmp(
+                                op,
+                                lval.typ.clone(),
+                                Value::Temp(lval),
+                                Value::Temp(rval),
+                            ),
                         );
                         Ok(tv)
-                    },
+                    }
                     Op::Arr => {
                         // Slice
                         if let Expr::Range(ref t, ref lower, ref upper) = *box_rhs {
                             // TODO: always assumes we are slicing an array, might not always be true
                             let lloc = box_lhs.loc();
                             let rloc = box_rhs.loc();
-                            
+
                             let lval = self.emit_expr(comptime, *box_lhs, None)?;
-                            lval.typ.assert_indexable(lloc.clone())?;
-                            let base = temp![self.get_indexable_ptr(&lval), TypeKind::U64.into()];
-                            let base_count = match lval.typ.struct_kind {
-                                StructKind::Array => {
-                                    let constexpr = lval.typ.elements.const_resolve();
-                                    let ConstExpr::Number(n) = constexpr else { unreachable!("user land error") };
-                                    
+                            lval.typ.assert_indexable(lloc.clone(), comptime)?;
+                            let base = temp![self.get_indexable_ptr(&lval), Type::U64];
+                            let (base_count, typeid) = match lval.typ {
+                                Type::Array(lazyexpr, typeid) => {
+                                    let constexpr = lazyexpr.const_resolve();
+                                    let ConstExpr::Number(n) = constexpr else {
+                                        unreachable!("user land error")
+                                    };
+
                                     let bc = self.ctx.alloc();
                                     let tv = self.block_add_assign(
-                                        temp![bc, TypeKind::U64.into()],
-                                        Instruction::Copy(Value::Constant(format!("{}", n)))
+                                        temp![bc, Type::U64],
+                                        Instruction::Copy(Value::Constant(format!("{}", n))),
                                     );
-                                    tv
+                                    (tv, typeid)
                                 }
-                                StructKind::Slice => {
+                                Type::Slice(typeid) => {
                                     let bc_ptr = self.ctx.alloc();
                                     let tv_ptr = self.block_add_assign(
-                                        temp![bc_ptr, TypeKind::U64.into()],
-                                        Instruction::Add(Value::Temp(lval.clone()), Value::Constant("8".into()))
+                                        temp![bc_ptr, Type::U64],
+                                        Instruction::Add(
+                                            Value::Temp(lval.clone()),
+                                            Value::Constant("8".into()),
+                                        ),
                                     );
                                     let bc = self.ctx.alloc();
                                     let tv = self.block_add_assign(
-                                        temp![bc, TypeKind::U64.into()],
-                                        Instruction::Load(Value::Temp(tv_ptr), TypeKind::U64.into())
+                                        temp![bc, Type::U64],
+                                        Instruction::Load(
+                                            Value::Temp(tv_ptr),
+                                            Type::U64,
+                                        ),
                                     );
-                                    tv
-                                },
-                                _ => return Err(error!(lloc, "Cannot index type {}", (lval.typ))),
+                                    (tv, typeid)
+                                }
+                                _ => return Err(error!(lloc, "Cannot index type {}", (lval.typ.display(comptime)))),
                             };
 
                             // Make the slice
-                            let Some(ref inner) = lval.typ.inner else { unreachable!() };
-                            let slice_type = Type::wrap(*inner.clone(), StructKind::Slice, LazyExpr::default(), false);
+                            let inner = comptime.fetch_type(typeid).unwrap().clone();
+                            let slice_type = Type::Slice(typeid);
 
                             let tag = self.ctx.alloc();
                             let tag_tv = self.block_add_assign(
-                                temp![tag, TypeKind::U64.into()],
-                                Instruction::Alloc(slice_type.clone())
+                                temp![tag, Type::U64],
+                                Instruction::Alloc(slice_type.clone()),
                             );
                             let sz_ptr = self.ctx.alloc();
                             let sz_ptr_tv = self.block_add_assign(
-                                temp![sz_ptr, TypeKind::U64.into()],
-                                Instruction::Add(Value::Temp(tag_tv.clone()), Value::Constant("8".into()))
+                                temp![sz_ptr, Type::U64],
+                                Instruction::Add(
+                                    Value::Temp(tag_tv.clone()),
+                                    Value::Constant("8".into()),
+                                ),
                             );
 
                             // Calculate the pointer and the length based on the range provided
@@ -1216,33 +1536,44 @@ function l $.slice.len(l %slc) {{
 
                                     let ltag = self.ctx.alloc();
                                     let ltv = self.block_add_assign(
-                                        temp![ltag, TypeKind::U64.into()],
-                                        Instruction::Cast(Value::Temp(lower.clone()), TypeKind::U64.into(), lower.typ.clone())
+                                        temp![ltag, Type::U64],
+                                        Instruction::Cast(
+                                            Value::Temp(lower.clone()),
+                                            Type::U64,
+                                            lower.typ.clone(),
+                                        ),
                                     );
                                     let utag = self.ctx.alloc();
                                     let utv = self.block_add_assign(
-                                        temp![utag, TypeKind::U64.into()],
-                                        Instruction::Cast(Value::Temp(upper.clone()), TypeKind::U64.into(), upper.typ.clone())
+                                        temp![utag, Type::U64],
+                                        Instruction::Cast(
+                                            Value::Temp(upper.clone()),
+                                            Type::U64,
+                                            upper.typ.clone(),
+                                        ),
                                     );
 
                                     let bytes = self.ctx.alloc();
                                     let bytes_tv = self.block_add_assign(
-                                        temp![bytes, TypeKind::U64.into()],
-                                        Instruction::Mul(Value::Temp(ltv.clone()), Value::Constant(format!("{}", inner.sizeof())))
+                                        temp![bytes, Type::U64],
+                                        Instruction::Mul(
+                                            Value::Temp(ltv.clone()),
+                                            Value::Constant(format!("{}", inner.sizeof(comptime))),
+                                        ),
                                     );
                                     let ptr = self.ctx.alloc();
                                     let ptr_tv = self.block_add_assign(
-                                        temp![ptr, TypeKind::U64.into()],
-                                        Instruction::Add(Value::Temp(base), Value::Temp(bytes_tv))
+                                        temp![ptr, Type::U64],
+                                        Instruction::Add(Value::Temp(base), Value::Temp(bytes_tv)),
                                     );
 
                                     let count = self.ctx.alloc();
                                     let count_tv = self.block_add_assign(
-                                        temp![count, TypeKind::U64.into()],
-                                        Instruction::Sub(Value::Temp(utv), Value::Temp(ltv))
+                                        temp![count, Type::U64],
+                                        Instruction::Sub(Value::Temp(utv), Value::Temp(ltv)),
                                     );
                                     (ptr_tv, count_tv)
-                                },
+                                }
                                 (Some(bl), None) => {
                                     let lower_loc = bl.loc();
                                     let lower = self.emit_expr(comptime, *bl, None)?;
@@ -1250,28 +1581,35 @@ function l $.slice.len(l %slc) {{
 
                                     let ltag = self.ctx.alloc();
                                     let ltv = self.block_add_assign(
-                                        temp![ltag, TypeKind::U64.into()],
-                                        Instruction::Cast(Value::Temp(lower.clone()), TypeKind::U64.into(), lower.typ.clone())
+                                        temp![ltag, Type::U64],
+                                        Instruction::Cast(
+                                            Value::Temp(lower.clone()),
+                                            Type::U64,
+                                            lower.typ.clone(),
+                                        ),
                                     );
 
                                     let bytes = self.ctx.alloc();
                                     let bytes_tv = self.block_add_assign(
-                                        temp![bytes, TypeKind::U64.into()],
-                                        Instruction::Mul(Value::Temp(ltv.clone()), Value::Constant(format!("{}", inner.sizeof())))
+                                        temp![bytes, Type::U64],
+                                        Instruction::Mul(
+                                            Value::Temp(ltv.clone()),
+                                            Value::Constant(format!("{}", inner.sizeof(comptime))),
+                                        ),
                                     );
                                     let ptr = self.ctx.alloc();
                                     let ptr_tv = self.block_add_assign(
-                                        temp![ptr, TypeKind::U64.into()],
-                                        Instruction::Add(Value::Temp(base), Value::Temp(bytes_tv))
+                                        temp![ptr, Type::U64],
+                                        Instruction::Add(Value::Temp(base), Value::Temp(bytes_tv)),
                                     );
 
                                     let count = self.ctx.alloc();
                                     let count_tv = self.block_add_assign(
-                                        temp![count, TypeKind::U64.into()],
-                                        Instruction::Sub(Value::Temp(base_count), Value::Temp(ltv))
+                                        temp![count, Type::U64],
+                                        Instruction::Sub(Value::Temp(base_count), Value::Temp(ltv)),
                                     );
                                     (ptr_tv, count_tv)
-                                },
+                                }
                                 (None, Some(bu)) => {
                                     let upper_loc = bu.loc();
                                     let upper = self.emit_expr(comptime, *bu, None)?;
@@ -1279,197 +1617,268 @@ function l $.slice.len(l %slc) {{
 
                                     let utag = self.ctx.alloc();
                                     let utv = self.block_add_assign(
-                                        temp![utag, TypeKind::U64.into()],
-                                        Instruction::Cast(Value::Temp(upper.clone()), TypeKind::U64.into(), upper.typ.clone())
+                                        temp![utag, Type::U64],
+                                        Instruction::Cast(
+                                            Value::Temp(upper.clone()),
+                                            Type::U64,
+                                            upper.typ.clone(),
+                                        ),
                                     );
 
                                     (base, utv)
-                                },
-                                (None, None) => {
-                                    (base, base_count)
-                                },
+                                }
+                                (None, None) => (base, base_count),
                             };
 
                             // Store the range (no offsetting the ptr or anything here)
-                            self.block_add_discard(Instruction::Store(Value::Temp(tag_tv), Value::Temp(final_ptr), TypeKind::U64.into()));
-                            self.block_add_discard(Instruction::Store(Value::Temp(sz_ptr_tv), Value::Temp(final_count), TypeKind::U64.into()));
-                            return Ok(temp![tag, Type::wrap(*inner.clone(), StructKind::Slice, LazyExpr::default(), false)])
+                            self.block_add_discard(Instruction::Store(
+                                Value::Temp(tag_tv),
+                                Value::Temp(final_ptr),
+                                Type::U64,
+                            ));
+                            self.block_add_discard(Instruction::Store(
+                                Value::Temp(sz_ptr_tv),
+                                Value::Temp(final_count),
+                                Type::U64,
+                            ));
+                            return Ok(temp![
+                                tag,
+                                slice_type
+                            ]);
                         }
 
                         // Array
                         let lloc = box_lhs.loc();
                         let rloc = box_rhs.loc();
-                        
+
                         let lval = self.emit_expr(comptime, *box_lhs, None)?;
                         let rval = self.emit_expr(comptime, *box_rhs, None)?;
-                        lval.typ.assert_indexable(lloc)?;
+                        lval.typ.assert_indexable(lloc, comptime)?;
                         rval.typ.assert_number(rloc)?;
-                        let base = temp![self.get_indexable_ptr(&lval), TypeKind::U64.into()];
- 
+                        let base = temp![self.get_indexable_ptr(&lval), Type::U64];
+
                         // We need the index to be a 64 bit value
                         // TODO: maybe factor this out too?
                         let rtag = self.ctx.alloc();
                         let rtv = self.block_add_assign(
-                            temp![rtag, TypeKind::U64.into()],
-                            Instruction::Cast(Value::Temp(rval.clone()), TypeKind::U64.into(), rval.typ.clone())
+                            temp![rtag, Type::U64],
+                            Instruction::Cast(
+                                Value::Temp(rval.clone()),
+                                Type::U64,
+                                rval.typ.clone(),
+                            ),
                         );
 
                         let bytes = self.ctx.alloc();
                         let ptr = self.ctx.alloc();
 
                         if lval.typ.is_ptr() {
-                            let deref = lval.typ.deref();
+                            let deref = lval.typ.deref(comptime);
                             let bytes_tv = self.block_add_assign(
-                                temp![bytes, TypeKind::U64.into()],
-                                Instruction::Mul(Value::Temp(rtv), Value::Constant(format!("{}", deref.sizeof())))
+                                temp![bytes, Type::U64],
+                                Instruction::Mul(
+                                    Value::Temp(rtv),
+                                    Value::Constant(format!("{}", deref.sizeof(comptime))),
+                                ),
                             );
                             let ptr_tv = self.block_add_assign(
-                                temp![ptr, TypeKind::U64.into()],
-                                Instruction::Add(Value::Temp(base), Value::Temp(bytes_tv))
+                                temp![ptr, Type::U64],
+                                Instruction::Add(Value::Temp(base), Value::Temp(bytes_tv)),
                             );
 
                             let tag = self.ctx.alloc();
                             let tag_tv = self.block_add_assign(
                                 temp![tag, deref.clone()],
-                                Instruction::Load(Value::Temp(ptr_tv), deref)
+                                Instruction::Load(Value::Temp(ptr_tv), deref),
                             );
                             Ok(tag_tv)
                         } else {
-                            let Some(ref inner) = lval.typ.inner else { unreachable!() };
+                            let inner = lval.typ.get_inner(comptime).unwrap();
                             let bytes_tv = self.block_add_assign(
-                                temp![bytes, TypeKind::U64.into()],
-                                Instruction::Mul(Value::Temp(rtv), Value::Constant(format!("{}", inner.sizeof())))
+                                temp![bytes, Type::U64],
+                                Instruction::Mul(
+                                    Value::Temp(rtv),
+                                    Value::Constant(format!("{}", inner.sizeof(comptime))),
+                                ),
                             );
                             let ptr_tv = self.block_add_assign(
-                                temp![ptr, TypeKind::U64.into()],
-                                Instruction::Add(Value::Temp(base), Value::Temp(bytes_tv))
+                                temp![ptr, Type::U64],
+                                Instruction::Add(Value::Temp(base), Value::Temp(bytes_tv)),
                             );
 
                             let tag = self.ctx.alloc();
                             let tag_tv = self.block_add_assign(
-                                temp![tag, *inner.clone()],
-                                Instruction::Load(Value::Temp(ptr_tv), *inner.clone())
+                                temp![tag, inner.clone()],
+                                Instruction::Load(Value::Temp(ptr_tv), inner.clone()),
                             );
                             Ok(tag_tv)
                         }
-                    },
+                    }
                     Op::Dot => {
                         let lloc = box_lhs.loc();
                         let rloc = box_rhs.loc();
-                        
+
                         let lval = self.emit_expr(comptime, *box_lhs, None)?;
                         let Expr::Call(box_expr, _) = *box_rhs else {
-                            return Err(error!(rloc, "Rhs of . operator does not look like a method call"));
+                            return Err(error!(
+                                rloc,
+                                "Rhs of . operator does not look like a method call"
+                            ));
                         };
                         let Expr::Ident(Token::Ident(loc, text)) = *box_expr else {
-                            return Err(error!(rloc, "Rhs of . operator does not look like a method call"));
+                            return Err(error!(
+                                rloc,
+                                "Rhs of . operator does not look like a method call"
+                            ));
                         };
-                        if let Some(mtd_map) = comptime.method_map.get(&Generator::type_to_builtin_check(&lval.typ)) {
+                        let built_in = Generator::type_to_builtin_check(&lval.typ, comptime);
+                        if let Some(mtd_map) = comptime
+                            .method_map
+                            .get(&built_in)
+                        {
                             if let Some(decl) = mtd_map.get(&text) {
                                 if lval.typ.is_struct() {
-                                    match lval.typ.struct_kind {
-                                        StructKind::Slice => {
+                                    match lval.typ {
+                                        Type::Slice(..) => {
                                             // Built in
                                             let tag = self.ctx.alloc();
                                             let tv = self.block_add_assign(
-                                                temp![tag, decl.ret_type.clone().unwrap_or(TypeKind::Void.into())],
+                                                temp![
+                                                    tag,
+                                                    decl.ret_type
+                                                        .clone()
+                                                        .map(|at| at.as_type(comptime))
+                                                        .unwrap_or(Type::Void)
+                                                ],
                                                 // Note: for methods we pass the object by a pointer
-                                                Instruction::Call(Value::Global(format!(".slice.{text}")), vec![temp![lval.tag, lval.typ.ptr()]])
+                                                Instruction::Call(
+                                                    Value::Global(format!(".slice.{text}")),
+                                                    vec![temp![lval.tag, lval.typ.ptr(comptime)]],
+                                                ),
                                             );
                                             Ok(tv)
                                             //genf!(self, "%.s{tag} =l call $.slice.{}(l %.s{})", text, lval);
                                             //Ok(StackValue{tag, typ: decl.ret_type.clone().unwrap_or(TypeKind::Void.into())})
-                                        },
-                                        _ => todo!()
+                                        }
+                                        _ => todo!(),
                                     }
                                 } else {
                                     todo!()
                                 }
                             } else {
-                                return Err(error!(loc, "No method `{}` found on type {}", text, (lval.typ)));
+                                return Err(error!(
+                                    loc,
+                                    "No method `{}` found on type {}",
+                                    text,
+                                    (lval.typ.display(comptime))
+                                ));
                             }
                         } else {
-                            Err(error!(lloc, "No methods exist for type {}", (lval.typ)))
+                            Err(error!(lloc, "No methods exist for type {}", (lval.typ.display(comptime))))
                         }
-                    },
+                    }
                     op => todo!("all remaining binary operators: {op:?}"),
                 }
-            },
+            }
             Expr::UnOp(_, ch, box_expr, postfix) => {
                 match ch {
-                    Op::Sub => {
-                        match *box_expr {
-                            Expr::Number(token) => {
-                                let Token::Int(_, i) = token else { unreachable!() };
+                    Op::Sub => match *box_expr {
+                        Expr::Number(token) => {
+                            let Token::Int(_, i) = token else {
+                                unreachable!()
+                            };
 
-                                let tag = self.ctx.alloc();
-                                let typ = expected_type.unwrap_or(TypeKind::S32.into());
-                                let tv = self.block_add_assign(
-                                    temp![tag, typ],
-                                    Instruction::Copy(Value::Constant(format!("-{i}")))
-                                );
-                                Ok(tv)
-                            },
-                            Expr::Ident(token) => todo!(),
-                            _ => unreachable!("Unsupported expr"),
+                            let tag = self.ctx.alloc();
+                            let typ = expected_type.map(|(e, _)| e).unwrap_or(Type::S32);
+                            let tv = self.block_add_assign(
+                                temp![tag, typ],
+                                Instruction::Copy(Value::Constant(format!("-{i}"))),
+                            );
+                            Ok(tv)
                         }
+                        Expr::Ident(token) => todo!(),
+                        _ => unreachable!("Unsupported expr"),
                     },
                     Op::And => {
                         match *box_expr {
                             Expr::Ident(token) => {
                                 // We should already allocate the variable as a pointer
-                                let Token::Ident(loc, text) = token else { unreachable!() };
+                                let Token::Ident(loc, text) = token else {
+                                    unreachable!()
+                                };
                                 let val = self.ctx.lookup(&text, loc)?;
-                                Ok(temp![val.tag, val.typ.ptr()])
-                            },
+                                Ok(temp![val.tag, val.typ.ptr(comptime)])
+                            }
                             _ => unreachable!("Unsupported expr"),
                         }
-                    },
+                    }
                     Op::Mul => {
                         let loc = box_expr.loc();
                         let ptr = self.emit_expr(comptime, *box_expr, None)?;
 
                         if !ptr.typ.is_ptr() {
-                            return Err(error!(loc, "Cannot dereference a non-pointer type {}", (ptr.typ)));
+                            return Err(error!(
+                                loc,
+                                "Cannot dereference a non-pointer type {}",
+                                (ptr.typ.display(comptime))
+                            ));
                         }
-                        
-                        let deref = ptr.typ.deref();
+
+                        let deref = ptr.typ.deref(comptime);
                         let tv = load!(self, deref.clone(), ptr);
                         Ok(tv)
-                    },
+                    }
                     Op::Implicit => {
                         let loc = box_expr.loc();
                         let val = self.emit_expr(comptime, *box_expr, None)?;
-                        if let Some(typ) = expected_type {
-                            if !typ.assert_number(loc.clone()).is_ok() && !val.typ.assert_number(loc.clone()).is_ok() {
-                                return Err(error!(loc, "Only implicit conversions between integers are supported!"));
+                        if let Some((typ, _)) = expected_type {
+                            if !typ.assert_number(loc.clone()).is_ok()
+                                && !val.typ.assert_number(loc.clone()).is_ok()
+                            {
+                                return Err(error!(
+                                    loc,
+                                    "Only implicit conversions between integers are supported!"
+                                ));
                             }
                             let tag = self.ctx.alloc();
                             let tv = self.block_add_assign(
                                 temp![tag, typ.clone()],
-                                Instruction::Cast(Value::Temp(val.clone()), typ, val.typ.clone())
+                                Instruction::Cast(Value::Temp(val.clone()), typ, val.typ.clone()),
                             );
                             Ok(tv)
                         } else {
-                            return Err(error!(loc, "Need a type to infer for implicit conversion!"))
+                            return Err(error!(
+                                loc,
+                                "Need a type to infer for implicit conversion!"
+                            ));
                         }
-                    },
+                    }
                     c => todo!("op `{c:?}`"),
                 }
-            },
+            }
             Expr::Func(_, params, ret_type, stmts, _, _) => {
                 unreachable!("TBD: Should I put emit_function in here?")
-            },
+            }
             Expr::FuncDecl(_, _, _, _) => {
                 unreachable!("can't declare functions within functions")
-            },
+            }
             Expr::Call(box_expr, mut args) => {
                 match *box_expr {
                     Expr::Ident(token) => {
-                        let Token::Ident(loc, text) = token else { unreachable!() };
+                        let Token::Ident(loc, text) = token else {
+                            unreachable!()
+                        };
                         let local_func = self.decorated_mod.parse_module.function_map.get(&text);
-                        gen_funcall_from_funcdef!(self, comptime, (self.generated_mod.name),local_func, &text, args, loc)
-                    },
+                        gen_funcall_from_funcdef!(
+                            self,
+                            comptime,
+                            (self.generated_mod.name),
+                            local_func,
+                            &text,
+                            args,
+                            loc
+                        )
+                    }
                     Expr::Path(token, box_expr) => {
                         let loc = token.loc();
                         let path = path_to_string(Expr::Path(token, box_expr));
@@ -1477,161 +1886,236 @@ function l $.slice.len(l %slc) {{
                         if let Some(module) = self.import_lookup(comptime, &modname) {
                             let func_name = get_func_name(path);
                             let imported_func = module.get(&func_name);
-                            gen_funcall_from_funcdef!(self, comptime, modname, imported_func, &func_name, args, loc)
+                            gen_funcall_from_funcdef!(
+                                self,
+                                comptime,
+                                modname,
+                                imported_func,
+                                &func_name,
+                                args,
+                                loc
+                            )
                         } else {
-                            if let Some((module, absolute_name)) = self.import_lookup_fuzzy(comptime, &modname) {
+                            if let Some((module, absolute_name)) =
+                                self.import_lookup_fuzzy(comptime, &modname)
+                            {
                                 let func_name = get_func_name(path);
                                 let imported_func = module.get(&func_name);
-                                gen_funcall_from_funcdef!(self, comptime, absolute_name, imported_func, &func_name, args, loc)
+                                gen_funcall_from_funcdef!(
+                                    self,
+                                    comptime,
+                                    absolute_name,
+                                    imported_func,
+                                    &func_name,
+                                    args,
+                                    loc
+                                )
                             } else {
                                 // TODO: Nicer name printing here
                                 return Err(error!(loc, "Unknown path `{modname}`"));
                             }
                         }
-                    },
+                    }
                     _ => return Err(error_orphan!("Got a function call without an identifier")),
                 }
-            },
+            }
             Expr::Null(token) => {
-                if let Some(typ) = expected_type {
+                if let Some((typ, _)) = expected_type {
                     let tag = self.ctx.alloc();
                     let tv = self.block_add_assign(
                         temp![tag, typ],
-                        Instruction::Copy(Value::Constant("0".into()))
+                        Instruction::Copy(Value::Constant("0".into())),
                     );
                     Ok(tv)
                 } else {
                     Err(error!(token.loc(), "Cannot infer type of null pointer"))
                 }
-            },
+            }
             Expr::InitList(token, mut exprs) => {
-                if let Some(mut typ) = expected_type {
-                    if typ.kind != TypeKind::Structure {
-                        return Err(error!(token.loc(), "Cannot initialize {typ} with initializer list"));
+                if let Some((mut typ, infer_elements)) = expected_type {
+                    if !typ.is_struct() {
+                        return Err(error!(
+                            token.loc(),
+                            "Cannot initialize {} with initializer list",
+                            (typ.display(comptime))
+                        ));
                     }
-                    match typ.struct_kind {
-                        StructKind::Array => {
-                            if typ.infer_elements {
-                                typ.elements = LazyExpr::make_constant(ConstExpr::Number(exprs.len() as i64));
-                                typ.infer_elements = false;
+                    match typ {
+                        Type::Array(ref mut lazyexpr, typeid) => {
+                            if infer_elements {
+                                *lazyexpr = LazyExpr::make_constant(ConstExpr::Number(exprs.len() as i64));
                             }
-                            typ.elements.const_eval(self)?;
-                            let constexpr = typ.elements.const_resolve();
-                            let ConstExpr::Number(n) = constexpr else { unreachable!("user land error") };
+                            lazyexpr.const_eval(self)?;
+                            let constexpr = lazyexpr.const_resolve();
+                            let ConstExpr::Number(n) = constexpr else {
+                                unreachable!("user land error")
+                            };
                             if n as usize != exprs.len() {
                                 // TODO: default constructors
-                                let Some(ref inner) = typ.inner else { unreachable!() };
+                                let inner = comptime.fetch_type(typeid).unwrap();
                                 if exprs.len() == 0 && inner.assert_number(ldef!()).is_ok() {
                                     for i in 0..n as usize {
                                         exprs.push(Expr::Number(Token::Int(ldef!(), 0)))
                                     }
                                     assert!(n as usize == exprs.len());
                                 } else {
-                                    return Err(error!(token.loc(), "Type expected {} arguments for initializer list", (n as usize)));
+                                    return Err(error!(
+                                        token.loc(),
+                                        "Type expected {} arguments for initializer list",
+                                        (n as usize)
+                                    ));
                                 }
                                 //return Err(error!(token.loc(), "Type expected {} arguments for initializer list but got {} instead", n, (exprs.len())));
                             }
 
                             // Update the expected type with our final length
                             // TODO I may be stupid I think this is unnecessary
-                            typ.elements = LazyExpr::make_constant(ConstExpr::Number(n));
+                            *lazyexpr = LazyExpr::make_constant(ConstExpr::Number(n));
 
                             // Make the array
-                            let Some(ref inner) = typ.inner else { unreachable!() };
-                            let sz = n as usize * inner.sizeof();
+                            let inner = comptime.fetch_type(typeid).unwrap().clone();
+                            let sz = n as usize * inner.sizeof(comptime);
                             if sz == 0 {
-                                return Err(error!(token.loc(), "Cannot make an array of size '0'!"));
+                                return Err(error!(
+                                    token.loc(),
+                                    "Cannot make an array of size '0'!"
+                                ));
                             }
 
                             let tag = self.ctx.alloc();
                             let tv = self.block_add_assign(
                                 temp![tag, typ.clone()],
-                                Instruction::Alloc(typ.clone())
+                                Instruction::Alloc(typ.clone()),
                             );
-                            
+
                             // Get the expressions
                             let mut vals = Vec::new();
                             for expr in exprs {
-                                let val = self.emit_expr(comptime, expr, Some(*inner.clone()))?;
+                                let val = self.emit_expr(comptime, expr, Some((inner.clone(), false)))?;
                                 vals.push(val);
                             }
 
                             // Type check the expressions and copy
                             for (i, val) in vals.iter().enumerate() {
-                                if val.typ != **inner {
-                                    return Err(error!(token.loc(), "Expected {} for array member, got {} instead", (*inner), (val.typ)));
+                                if val.typ != inner {
+                                    return Err(error!(
+                                        token.loc(),
+                                        "Expected {} for array member, got {} instead",
+                                        (inner.display(comptime)),
+                                        (val.typ.display(comptime))
+                                    ));
                                 }
-                                let ptr = array_offset!(self, tv, inner, i);
-                                self.block_add_discard(Instruction::Store(Value::Temp(ptr), Value::Temp(val.clone()), val.typ.clone()))
+                                let ptr = array_offset!(comptime, self, tv, inner, i);
+                                self.block_add_discard(Instruction::Store(
+                                    Value::Temp(ptr),
+                                    Value::Temp(val.clone()),
+                                    val.typ.clone(),
+                                ))
                             }
                             Ok(tv)
                         },
-                        StructKind::Slice => {
+                        Type::Slice(typeid) => {
                             if exprs.len() != 2 {
-                                return Err(error!(token.loc(), "Need exactly 2 arguments to initialize slice: {{ptr, len}}"));
+                                return Err(error!(
+                                    token.loc(),
+                                    "Need exactly 2 arguments to initialize slice: {{ptr, len}}"
+                                ));
                             }
-                            let Some(ref inner) = typ.inner else { unreachable!() };
+                            let inner = comptime.fetch_type(typeid).unwrap().clone();
                             let ptr_loc = exprs[0].loc();
                             let len_loc = exprs[1].loc();
                             let expr_1 = exprs.pop().unwrap();
                             let expr_0 = exprs.pop().unwrap();
-                            let ptr = self.emit_expr(comptime, expr_0, Some(*inner.clone()))?;
+                            let ptr = self.emit_expr(comptime, expr_0, Some((inner.clone(), false)))?;
                             let len = self.emit_expr(comptime, expr_1, None)?;
                             if !ptr.typ.is_ptr() {
-                                return Err(error!(ptr_loc, "Expected pointer for first field of slice"));
+                                return Err(error!(
+                                    ptr_loc,
+                                    "Expected pointer for first field of slice"
+                                ));
                             }
-                            let mut deref = ptr.typ.deref();
-                            if !deref.soft_equals(inner) {
-                                return Err(error!(ptr_loc, "Expected type of {typ}, got type of {} instead", (ptr.typ)));
+                            let mut deref = ptr.typ.deref(comptime);
+                            if !deref.check_coerce(&inner, comptime) {
+                                return Err(error!(
+                                    ptr_loc,
+                                    "Expected type of {}, got type of {} instead",
+                                    (typ.display(comptime)),
+                                    (ptr.typ.display(comptime))
+                                ));
                             }
                             if len.typ.assert_number(len_loc).is_err() {
-                                return Err(error!(ptr_loc, "Expected number for second field of slice"));
+                                return Err(error!(
+                                    ptr_loc,
+                                    "Expected number for second field of slice"
+                                ));
                             }
                             let ltag = self.ctx.alloc();
                             let long = self.block_add_assign(
-                                temp![ltag, TypeKind::U64.into()],
-                                Instruction::Cast(Value::Temp(len.clone()), TypeKind::U64.into(), len.typ.clone())
+                                temp![ltag, Type::U64],
+                                Instruction::Cast(
+                                    Value::Temp(len.clone()),
+                                    Type::U64,
+                                    len.typ.clone(),
+                                ),
                             );
 
                             let tag = self.ctx.alloc();
                             let offset = self.ctx.alloc();
-                            let slice_type = Type::wrap(*inner.clone(), StructKind::Slice, LazyExpr::default(), false);
+                            let slice_type = Type::Slice(typeid);
 
                             let tagtv = self.block_add_assign(
-                                temp![tag, Into::<Type>::into(TypeKind::Void).ptr()],
-                                Instruction::Alloc(slice_type.clone())
+                                temp![tag, Type::Void.ptr(comptime)],
+                                Instruction::Alloc(slice_type.clone()),
                             );
-                            self.block_add_discard(Instruction::Store(Value::Temp(tagtv.clone()), Value::Temp(ptr.clone()), ptr.typ.clone()));
+                            self.block_add_discard(Instruction::Store(
+                                Value::Temp(tagtv.clone()),
+                                Value::Temp(ptr.clone()),
+                                ptr.typ.clone(),
+                            ));
                             let offsettv = self.block_add_assign(
-                                temp![offset, Into::<Type>::into(TypeKind::Void).ptr()],
-                                Instruction::Add(Value::Temp(tagtv.clone()), Value::Constant("8".into()))
+                                temp![offset, Type::Void.ptr(comptime)],
+                                Instruction::Add(
+                                    Value::Temp(tagtv.clone()),
+                                    Value::Constant("8".into()),
+                                ),
                             );
-                            self.block_add_discard(Instruction::Store(Value::Temp(offsettv.clone()), Value::Temp(long.clone()), long.typ.clone()));
+                            self.block_add_discard(Instruction::Store(
+                                Value::Temp(offsettv.clone()),
+                                Value::Temp(long.clone()),
+                                long.typ.clone(),
+                            ));
                             Ok(temp![tagtv.tag, slice_type])
-                        },
-                        _ => return Err(error!(token.loc(), "Cannot initialize {typ} with initializer list")),
+                        }
+                        _ => {
+                            return Err(error!(
+                                token.loc(),
+                                "Cannot initialize {} with initializer list",
+                                (typ.display(comptime))
+                            ))
+                        }
                     }
                 } else {
                     Err(error!(token.loc(), "Cannot infer type of initializer list"))
                 }
-            },
+            }
             Expr::Range(token, upper, lower) => {
                 todo!("probably unreachable!");
-            },
-            Expr::Cast(token, box_expr, to_typ) => {
+            }
+            Expr::Cast(token, box_expr, to_ast_typ) => {
                 let loc = box_expr.loc();
-                let val = self.emit_expr(comptime, *box_expr, Some(to_typ.clone()))?;
+                let to_typ = to_ast_typ.as_type(comptime);
+                let val = self.emit_expr(comptime, *box_expr, Some((to_typ.clone(), false)))?;
                 if val.typ.assert_number(loc.clone()).is_ok() && to_typ.assert_number(loc).is_ok() {
                     let tag = self.ctx.alloc();
                     let tv = self.block_add_assign(
                         temp![tag, to_typ.clone()],
-                        Instruction::Cast(Value::Temp(val.clone()), to_typ, val.typ.clone())
+                        Instruction::Cast(Value::Temp(val.clone()), to_typ, val.typ.clone()),
                     );
                     Ok(tv)
                 } else {
                     todo!("unsupported conversion");
                 }
-            },
+            }
         }
     }
 }
@@ -1642,20 +2126,42 @@ pub struct Compiletime {
     module_map: HashMap<String, Module>,
     method_map: HashMap<Type, HashMap<String, FunctionDecl>>,
     main_defined: bool,
+    types: Vec<Type>,
 }
 
 impl Compiletime {
     pub fn add_module(&mut self, name: String, module: Module) {
         if self.module_map.get(&name).is_some() {
-            self.module_map.get_mut(&name).unwrap().extend(module.into_iter());
+            self.module_map
+                .get_mut(&name)
+                .unwrap()
+                .extend(module.into_iter());
         } else {
             self.module_map.insert(name, module);
         }
     }
-    
+
     pub fn get_module(&self, path: Expr) -> Option<&Module> {
         let s = path_to_string(path);
         self.module_map.get(&s)
+    }
+
+    // NOTE: This function will create a typeid if it doesn't exist yet
+    // Linear search should be reasonable for now
+    pub fn fetch_typeid(&mut self, typ1: &Type) -> TypeId {
+        for (i, typ2) in self.types.iter().enumerate() {
+            if typ1 == typ2 {
+                return TypeId(i);
+            }
+        }
+        // Not found, create one
+        let i = self.types.len();
+        self.types.push(typ1.clone());
+        return TypeId(i);
+    }
+
+    pub fn fetch_type(&self, tid: TypeId) -> Option<&Type> {
+        self.types.get(tid.0)
     }
 }
 
@@ -1665,6 +2171,7 @@ impl Compiletime {
             module_map: HashMap::new(),
             method_map: HashMap::new(),
             main_defined: false,
+            types: Vec::new(),
         }
     }
 
@@ -1676,7 +2183,9 @@ impl Compiletime {
             Backend::C => "cc".to_string(),
         };
         // TODO: prob not enough
-        if options.verbose_shell { println!("[CMD] {backend_path} {bf}{name}{suf} -o {bf}{name}.s") }
+        if options.verbose_shell {
+            println!("[CMD] {backend_path} {bf}{name}{suf} -o {bf}{name}.s")
+        }
         if !Command::new(&backend_path)
             .arg(&format!("{bf}{name}{suf}"))
             .arg("-o")
@@ -1690,7 +2199,11 @@ impl Compiletime {
         Ok(())
     }
 
-    pub fn emit(&mut self, mut decorated_mods: Vec<DecoratedModule>, options: &BuildOptions) -> Result<()> {
+    pub fn emit(
+        &mut self,
+        mut decorated_mods: Vec<DecoratedModule>,
+        options: &BuildOptions,
+    ) -> Result<()> {
         let mut objs = Vec::new();
         for decorated_mod in &decorated_mods {
             let name = path_to_string(decorated_mod.parse_module.name.clone());
@@ -1715,7 +2228,8 @@ impl Compiletime {
                 Backend::C => SUFFIX_C,
             };
 
-            let mut file = File::create(&format!("{bf}{name}{suf}")).or(Err(error_orphan!("Could not create qbe output file")))?;
+            let mut file = File::create(&format!("{bf}{name}{suf}"))
+                .or(Err(error_orphan!("Could not create qbe output file")))?;
             let _ = write!(file, "{}", generator.generated_mod.output);
 
             // .? -> .s
@@ -1723,12 +2237,10 @@ impl Compiletime {
 
             // .s -> .o
             let assembler_path = options.assembler_path.clone().unwrap_or("cc".to_string());
-            let debug_info = if options.debug_info {
-                "-g"
-            } else {
-                ""
-            };
-            if options.verbose_shell { println!("[CMD] {assembler_path} {debug_info} -c {bf}{name}.s -o {bf}{name}.o") }
+            let debug_info = if options.debug_info { "-g" } else { "" };
+            if options.verbose_shell {
+                println!("[CMD] {assembler_path} {debug_info} -c {bf}{name}.s -o {bf}{name}.o")
+            }
             // Rust is strange...
             let mut asm_cmd = &mut Command::new(&assembler_path);
             if debug_info.len() > 0 {
@@ -1743,12 +2255,16 @@ impl Compiletime {
                 .expect("ERROR: qbe not found")
                 .success()
             {
-                return Err(error_orphan!("Failure with getting object file from assembly"));
+                return Err(error_orphan!(
+                    "Failure with getting object file from assembly"
+                ));
             }
 
             if !options.emit_qbe {
                 let path = format!("{bf}{name}.ssa");
-                if options.verbose_shell { println!("[CMD] rm {path}") }
+                if options.verbose_shell {
+                    println!("[CMD] rm {path}")
+                }
                 if !Command::new("rm")
                     .arg(&path)
                     .status()
@@ -1761,7 +2277,9 @@ impl Compiletime {
 
             if !options.emit_assembly {
                 let path = format!("{bf}{name}.s");
-                if options.verbose_shell { println!("[CMD] rm {path}") }
+                if options.verbose_shell {
+                    println!("[CMD] rm {path}")
+                }
                 if !Command::new("rm")
                     .arg(&path)
                     .status()
@@ -1773,14 +2291,19 @@ impl Compiletime {
             }
 
             objs.push(format!("{bf}{name}.o"));
-            self.add_module(generator.generated_mod.name, generator.decorated_mod.parse_module.function_map);
+            self.add_module(
+                generator.generated_mod.name,
+                generator.decorated_mod.parse_module.function_map,
+            );
         }
 
         let output_name = options.output_name.clone().unwrap_or("b.out".to_string());
         if !options.compile_only {
             let linker_path = options.linker_path.clone().unwrap_or("cc".to_string());
             let linker_args = options.linker_arguments.clone();
-            if options.verbose_shell { println!("[CMD] {linker_path} {linker_args:?} {objs:?} -o {output_name}") }
+            if options.verbose_shell {
+                println!("[CMD] {linker_path} {linker_args:?} {objs:?} -o {output_name}")
+            }
             if !Command::new(linker_path)
                 .args(linker_args)
                 .args(objs.clone())
@@ -1794,7 +2317,9 @@ impl Compiletime {
             }
 
             for path in objs {
-                if options.verbose_shell { println!("[CMD] rm {path}") }
+                if options.verbose_shell {
+                    println!("[CMD] rm {path}")
+                }
                 if !Command::new("rm")
                     .arg(&path)
                     .status()
@@ -1808,7 +2333,7 @@ impl Compiletime {
         } else {
             println!("Created object files!");
         }
-        
+
         Ok(())
     }
 }

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -1,14 +1,19 @@
-use std::fmt;
+use std::fmt::{self, Write};
 
-use crate::ast::{Type, TypeKind, Param, Op, StructKind};
+use crate::ast::{Op, Param, Type};
 use crate::lexer::Location;
+use crate::Compiletime;
+
+pub trait BackendQBE {
+    fn dump(&self, f: &mut impl Write, comptime: &Compiletime) -> fmt::Result;
+}
 
 pub trait BackendLLVM {
-    fn dump(&self) -> String;
+    fn dump(&self, f: &mut impl Write, comptime: &Compiletime) -> fmt::Result;
 }
 
 pub trait BackendC {
-    fn dump(&self) -> String;
+    fn dump(&self, f: &mut impl Write, comptime: &Compiletime) -> fmt::Result;
 }
 
 #[derive(Clone, Debug)]
@@ -57,11 +62,11 @@ pub enum Instruction {
     Div(Value, Value),
     DivU(Value, Value),
     Call(Value, Vec<TempValue>), // TODO
-    Load(Value, Type), // ptr, as_type
-    Store(Value, Value, Type), // ptr, src, into_type
-    Alloc(Type), // TODO: will I need more?
-    Jmp(Value), // label
-    Jnz(Value, Value, Value), // test, labelT, labelF
+    Load(Value, Type),           // ptr, as_type
+    Store(Value, Value, Type),   // ptr, src, into_type
+    Alloc(Type),                 // TODO: will I need more?
+    Jmp(Value),                  // label
+    Jnz(Value, Value, Value),    // test, labelT, labelF
     Cmp(Op, Type, Value, Value),
     Cast(Value, Type, Type), // value, as_type, from_type
 }

--- a/src/main.eve
+++ b/src/main.eve
@@ -3,9 +3,13 @@ module hello;
 import std::io;
 
 main :: fn() {
-    let SIZE: usize :: 3;
-    let xs: [SIZE]u32 = {};
-    dbg xs[0];
-    dbg xs[1];
-    dbg xs[2];
+    let xs: [1][1]u32 = {{1}};
+    dbg xs;
 }
+
+// /*
+// 1: addr [][] (blitted 2 into here)
+// 2: addr [] (stores u32 1)
+// 9: copy 1
+// 10: deref 9 []
+// */

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,12 +1,12 @@
 use std::collections::HashMap;
 
-use crate::lexer::{Lexer, Token, Location};
 use crate::ast::*;
+use crate::lexer::{Lexer, Location, Token};
 
-use crate::precedence::*;
+use crate::const_eval::LazyExpr;
 use crate::errors::SyntaxError;
 use crate::gen::FunctionDecl;
-use crate::const_eval::LazyExpr;
+use crate::precedence::*;
 
 mod parse_expr;
 mod parse_stmt;
@@ -17,14 +17,19 @@ macro_rules! insert_func_with_attributes {
         for attr in $attrs {
             match attr {
                 Attribute::Extern(expr) => {
-                    let Expr::String(Token::String(_, text)) = expr else { unreachable!() };
+                    let Expr::String(Token::String(_, text)) = expr else {
+                        unreachable!()
+                    };
                     extern_name = Some(text);
-                },
+                }
                 _ => return Err(error_orphan!("Unsupported function attribute `{attr:?}`")),
             }
         }
-        $map.insert($name.clone(), FunctionDecl::new($params, $ret_type, $name, extern_name));
-    }
+        $map.insert(
+            $name.clone(),
+            FunctionDecl::new($params, $ret_type, $name, extern_name),
+        );
+    };
 }
 
 pub type Result<T> = std::result::Result<T, SyntaxError>;
@@ -34,13 +39,13 @@ pub struct ParseModule {
     pub file_stem: String,
     pub globals: Vec<Global>,
     pub function_map: HashMap<String, FunctionDecl>,
-    pub type_alias_map: HashMap<String, Type>,
+    pub type_alias_map: HashMap<String, AstType>,
 }
 
 pub struct Parser {
     lexer: Lexer,
     function_map: HashMap<String, FunctionDecl>,
-    type_alias_map: HashMap<String, Type>,
+    type_alias_map: HashMap<String, AstType>,
 }
 
 // Welcome home :/
@@ -51,16 +56,25 @@ pub struct Parser {
 // between types
 impl Parser {
     pub fn from(lexer: Lexer) -> Self {
-        Self { lexer, function_map: HashMap::new(), type_alias_map: HashMap::new() }
+        Self {
+            lexer,
+            function_map: HashMap::new(),
+            type_alias_map: HashMap::new(),
+        }
     }
 
     fn expect(&mut self, token: Token) -> Result<()> {
         let next = self.lexer.next();
         if next != token {
             return match next {
-                Token::Eof => Err(error_orphan!("Expected `{token:?}`, got end-of-file instead!")),
-                t => Err(error!(t.loc(), "Expected `{token:?}`, got `{t:?}` instead!")),
-            }
+                Token::Eof => Err(error_orphan!(
+                    "Expected `{token:?}`, got end-of-file instead!"
+                )),
+                t => Err(error!(
+                    t.loc(),
+                    "Expected `{token:?}`, got `{t:?}` instead!"
+                )),
+            };
         }
         Ok(())
     }
@@ -70,18 +84,24 @@ impl Parser {
     }
 
     fn default_type_aliases(&mut self) {
-        self.type_alias_map.insert("str".into(), Type::wrap(TypeKind::U8.into(), StructKind::Slice, LazyExpr::default(), false));
-        let u: Type = TypeKind::U8.into();
-        self.type_alias_map.insert("cstr".into(), u.ptr());
-        let usz: Type = TypeKind::U64.into();
+        self.type_alias_map.insert(
+            "str".into(),
+            AstType::Slice(Box::new(AstType::Base(Type::U8))),
+        );
+        let u: AstType = AstType::Base(Type::U8);
+        self.type_alias_map
+            .insert("cstr".into(), AstType::Ptr(Box::new(u)));
+        let usz: AstType = AstType::Base(Type::U64);
         self.type_alias_map.insert("usize".into(), usz);
     }
 
     pub fn parse(&mut self, file_stem: String) -> Result<ParseModule> {
         self.default_type_aliases();
-        let Global::DeclModule(name) = self.parse_module_decl()? else { unreachable!() };
+        let Global::DeclModule(name) = self.parse_module_decl()? else {
+            unreachable!()
+        };
         let mut globals = Vec::new();
-        
+
         while !self.eof() {
             if let Some(import) = self.parse_import()? {
                 globals.push(import);
@@ -95,13 +115,13 @@ impl Parser {
             }
         }
 
-        Ok(ParseModule{
+        Ok(ParseModule {
             name,
             file_stem,
             globals,
             function_map: self.function_map.clone(),
-            type_alias_map: self.type_alias_map.clone()}
-        )
+            type_alias_map: self.type_alias_map.clone(),
+        })
     }
 
     pub fn parse_expr_string(&mut self) -> Result<Expr> {
@@ -110,7 +130,7 @@ impl Parser {
             Token::String(_, _) => {
                 self.lexer.next();
                 Ok(Expr::String(token))
-            },
+            }
             Token::Eof => Err(error_orphan!("No string present")),
             t => Err(error!(t.loc(), "No string present")),
         }
@@ -122,18 +142,20 @@ impl Parser {
             Token::Ident(_, _) => {
                 self.lexer.next();
                 Ok(Expr::Ident(token))
-            },
+            }
             Token::Eof => Err(error_orphan!("No identifier present")),
             t => Err(error!(t.loc(), "No identifier present")),
         }
     }
-    
+
     pub fn parse_expr_path(&mut self) -> Result<Expr> {
         let mut path = self.parse_expr_ident()?;
         while let Token::WideOp(_, (':', ':')) = self.lexer.peek() {
             self.lexer.next();
 
-            let Expr::Ident(token) = path else { unreachable!() };
+            let Expr::Ident(token) = path else {
+                unreachable!()
+            };
             let rhs = self.parse_expr_path()?;
             path = Expr::Path(token, Box::new(rhs))
         }
@@ -146,9 +168,11 @@ impl Parser {
     pub fn parse_module_decl(&mut self) -> Result<Global> {
         if !self.lexer.eat(Token::Module(ldef!())) {
             return match self.lexer.peek() {
-                Token::Eof => Err(error_orphan!("Module header is required! Got empty file instead.")),
+                Token::Eof => Err(error_orphan!(
+                    "Module header is required! Got empty file instead."
+                )),
                 t => Err(error!(t.loc(), "Module header is required!")),
-            }
+            };
         }
 
         let decl = Global::DeclModule(self.parse_expr_path()?);
@@ -177,7 +201,9 @@ impl Parser {
             return Ok(None);
         }
 
-        let Expr::Ident(Token::Ident(loc, text)) = self.parse_expr_ident()? else { unreachable!() };
+        let Expr::Ident(Token::Ident(loc, text)) = self.parse_expr_ident()? else {
+            unreachable!()
+        };
         self.expect(Token::Op(ldef!(), '='))?;
         let typ = self.parse_type()?;
         self.expect(Token::Op(ldef!(), ';'))?;
@@ -187,7 +213,7 @@ impl Parser {
         }
 
         self.type_alias_map.insert(text, typ);
-        
+
         Ok(Some(()))
     }
 
@@ -195,19 +221,43 @@ impl Parser {
     <global> ::= ID '::' <expr>
     */
     pub fn parse_global(&mut self) -> Result<Global> {
-        let Expr::Ident(token) = self.parse_expr_ident()? else { unreachable!() };
+        let Expr::Ident(token) = self.parse_expr_ident()? else {
+            unreachable!()
+        };
         self.expect(Token::WideOp(ldef!(), (':', ':')))?;
         let expr = self.parse_expr()?;
-        
+
         if let Expr::Func(fn_, params, ret_type, stmts, returns, attrs) = expr {
-            let Token::Ident(_, text) = token.clone() else { unreachable!() };
-            insert_func_with_attributes!((self.function_map), text, (params.clone()), (ret_type.clone()), (attrs.clone()));
-            Ok(Global::Decl(token, Expr::Func(fn_, params, ret_type, stmts, returns, attrs)))
+            let Token::Ident(_, text) = token.clone() else {
+                unreachable!()
+            };
+            insert_func_with_attributes!(
+                (self.function_map),
+                text,
+                (params.clone()),
+                (ret_type.clone()),
+                (attrs.clone())
+            );
+            Ok(Global::Decl(
+                token,
+                Expr::Func(fn_, params, ret_type, stmts, returns, attrs),
+            ))
         } else {
             if let Expr::FuncDecl(fn_, params, ret_type, attrs) = expr {
-                let Token::Ident(_, text) = token.clone() else { unreachable!() };
-                insert_func_with_attributes!((self.function_map), text, (params.clone()), (ret_type.clone()), (attrs.clone()));
-                Ok(Global::Decl(token, Expr::FuncDecl(fn_, params, ret_type, attrs)))
+                let Token::Ident(_, text) = token.clone() else {
+                    unreachable!()
+                };
+                insert_func_with_attributes!(
+                    (self.function_map),
+                    text,
+                    (params.clone()),
+                    (ret_type.clone()),
+                    (attrs.clone())
+                );
+                Ok(Global::Decl(
+                    token,
+                    Expr::FuncDecl(fn_, params, ret_type, attrs),
+                ))
             } else {
                 Ok(Global::Decl(token, expr))
             }
@@ -218,17 +268,21 @@ impl Parser {
     #extern("symbol")
     */
     pub fn parse_attribute(&mut self) -> Result<Option<Attribute>> {
-        if std::mem::discriminant(&Token::Attribute(ldef!(), "".into())) != std::mem::discriminant(&self.lexer.peek()) {
+        if std::mem::discriminant(&Token::Attribute(ldef!(), "".into()))
+            != std::mem::discriminant(&self.lexer.peek())
+        {
             return Ok(None);
         }
-        let Token::Attribute(loc, name) = self.lexer.next() else { unreachable!() };
+        let Token::Attribute(loc, name) = self.lexer.next() else {
+            unreachable!()
+        };
         match &name[..] {
             "#extern" => {
                 self.expect(Token::Op(ldef!(), '('))?;
                 let symbol = self.parse_expr_string()?;
                 self.expect(Token::Op(ldef!(), ')'))?;
                 Ok(Some(Attribute::Extern(symbol)))
-            },
+            }
             _ => Err(error!(loc, "Unknown attribute `{name}`")),
         }
     }

--- a/src/precedence.rs
+++ b/src/precedence.rs
@@ -1,8 +1,8 @@
 // The general rule is that we use an odd priority as base, and bump it by one for associativity, if the operator is binary
 
 use crate::ast::Op;
-use crate::parser::Result;
 use crate::errors::SyntaxError;
+use crate::parser::Result;
 
 pub fn infix_binding_power(op: Op) -> Option<(u8, u8)> {
     let res = match op {

--- a/src/target.rs
+++ b/src/target.rs
@@ -63,15 +63,27 @@ impl Target {
     pub fn from(os: Os, arch: Arch, backend: Backend) -> Self {
         Self { os, arch, backend }
     }
-    
-    pub fn os(&self) -> Os { self.os }
-    pub fn arch(&self) -> Arch { self.arch }
-    pub fn backend(&self) -> Backend { self.backend }
 
-    pub fn set_os(&mut self, os: Os) { self.os = os }
-    pub fn set_arch(&mut self, arch: Arch) { self.arch = arch }
-    pub fn set_backend(&mut self, backend: Backend) { self.backend = backend }
-    
+    pub fn os(&self) -> Os {
+        self.os
+    }
+    pub fn arch(&self) -> Arch {
+        self.arch
+    }
+    pub fn backend(&self) -> Backend {
+        self.backend
+    }
+
+    pub fn set_os(&mut self, os: Os) {
+        self.os = os
+    }
+    pub fn set_arch(&mut self, arch: Arch) {
+        self.arch = arch
+    }
+    pub fn set_backend(&mut self, backend: Backend) {
+        self.backend = backend
+    }
+
     pub fn can_debug_info(&self) -> bool {
         match self.backend {
             Backend::Qbe => false,
@@ -79,7 +91,7 @@ impl Target {
             Backend::C => true,
         }
     }
-    
+
     pub fn can_backtrace(&self) -> bool {
         self.can_debug_info()
     }


### PR DESCRIPTION
Originally, I had thought tagged unions were not ideal as I wanted a typeid system. I had designed my initial Type structure to be able to be packed into a 64-bit integer, but over time that goal was not sufficient enough for my needs. Upon researching pattern matching, I realized types can be stored in a global vector with indices indicating the type id. So, this commit reworks types to be much simpler and to support a type id system (without regards to modules yet).