### PR TITLE
Change assignments of globals from `::` to `:=`

### DIFF
--- a/examples/rule110.eve
+++ b/examples/rule110.eve
@@ -2,7 +2,7 @@ module rule110;
 
 import std::io;
 
-check :: fn(tape: [80]u8, buf: []u8, i: s32) {
+check := fn(tape: [80]u8, buf: []u8, i: s32) {
     let O = " ";
     let I = "#";
     if tape[i] == 1 && tape[i+1] == 1 && tape[i+2] == 1 {
@@ -39,7 +39,7 @@ check :: fn(tape: [80]u8, buf: []u8, i: s32) {
     }
 }
 
-main :: fn() {
+main := fn() {
     let tape: [80]u8 = {};
     tape[80 - 1] = 1;
 

--- a/src/main.eve
+++ b/src/main.eve
@@ -1,8 +1,10 @@
 module hello;
 
-import foo::number;
+import std::io;
+import libc::io;
 
-main :: fn() {
-    let xs: [1][1]foo::number = {{1}};
+main := fn() {
+    let SIZE := 3;
+    let xs: [SIZE]u32 = {};
     dbg xs;
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -224,7 +224,7 @@ impl Parser {
         let Expr::Ident(token) = self.parse_expr_ident()? else {
             unreachable!()
         };
-        self.expect(Token::WideOp(ldef!(), (':', ':')))?;
+        self.expect(Token::WideOp(ldef!(), (':', '=')))?;
         let expr = self.parse_expr()?;
 
         if let Expr::Func(fn_, params, ret_type, stmts, returns, attrs) = expr {

--- a/std/io.eve
+++ b/std/io.eve
@@ -2,11 +2,11 @@ module std::io;
 
 import libc::io;
 
-print :: fn(s: str) {
+print := fn(s: str) {
     libc::io::write(1, s.ptr(), s.len());
 }
 
-println :: fn(s: str) {
+println := fn(s: str) {
     let nl = "\n";
     libc::io::write(1, s.ptr(), s.len());
     libc::io::write(1, nl.ptr(), nl.len());

--- a/std/libc/io.eve
+++ b/std/libc/io.eve
@@ -1,7 +1,7 @@
 module libc::io;
 
-puts :: fn(s: cstr) -> s32 #extern("puts");
-putchar :: fn(c: s32) -> s32 #extern("putchar");
+puts := fn(s: cstr) -> s32 #extern("puts");
+putchar := fn(c: s32) -> s32 #extern("putchar");
 
-read :: fn(fd: s32, buffer: *void, size: usize) -> s64 #extern("read");
-write :: fn(fd: s32, buffer: *void, size: usize) -> s64 #extern("write");
+read := fn(fd: s32, buffer: *void, size: usize) -> s64 #extern("read");
+write := fn(fd: s32, buffer: *void, size: usize) -> s64 #extern("write");

--- a/std/libc/mem.eve
+++ b/std/libc/mem.eve
@@ -1,5 +1,5 @@
 module libc::mem;
 
-malloc :: fn(size: usize) -> *void #extern("malloc");
-free :: fn(ptr: *void) #extern("free");
-realloc :: fn(ptr: *void, newsize: usize) -> *void #extern("realloc");
+malloc := fn(size: usize) -> *void #extern("malloc");
+free := fn(ptr: *void) #extern("free");
+realloc := fn(ptr: *void, newsize: usize) -> *void #extern("realloc");

--- a/std/libc/proc.eve
+++ b/std/libc/proc.eve
@@ -2,7 +2,7 @@ module libc::proc;
 
 type pid = s32;
 
-fork :: fn() -> pid #extern("fork");
-execv :: fn(filename: cstr, argv: **u8) -> s32 #extern("execv");
-execve :: fn(filename: cstr, argv: **u8, env: **u8) -> s32 #extern("execve");
-execvp :: fn(filename: cstr, argv: **u8) -> s32 #extern("execvp");
+fork := fn() -> pid #extern("fork");
+execv := fn(filename: cstr, argv: **u8) -> s32 #extern("execv");
+execve := fn(filename: cstr, argv: **u8, env: **u8) -> s32 #extern("execve");
+execvp := fn(filename: cstr, argv: **u8) -> s32 #extern("execvp");

--- a/tests/addrof.eve
+++ b/tests/addrof.eve
@@ -1,6 +1,6 @@
 module hello;
 
-main :: fn() {
+main := fn() {
     let x = 5;
     let y = &x;
     dbg *y;

--- a/tests/algebra.eve
+++ b/tests/algebra.eve
@@ -1,6 +1,6 @@
 module hello;
 
-main :: fn() {
+main := fn() {
     let a: u64 = 120 / 10;
     let b: u32 = 120 / 10;
     let c: u16 = 120 / 10;

--- a/tests/array1.eve
+++ b/tests/array1.eve
@@ -1,6 +1,6 @@
 module hello;
 
-main :: fn() {
+main := fn() {
     // let arr: [3]u32 = {1, 2, 3};
     // dbg arr;
     // Interesting

--- a/tests/array2.eve
+++ b/tests/array2.eve
@@ -1,6 +1,6 @@
 module hello;
 
-main :: fn() {
+main := fn() {
     let arr: [3]u32 = {1, 2, 3};
     dbg arr;
     let arr2: [1][3]u32 = {{1, 2, 3}};
@@ -16,6 +16,6 @@ main :: fn() {
     // foo(a); works but changes every run bcs pointer
 }
 
-foo :: fn(x: [1]*s32) {
+foo := fn(x: [1]*s32) {
     dbg x;
 }

--- a/tests/array3.eve
+++ b/tests/array3.eve
@@ -1,6 +1,6 @@
 module hello;
 
-main :: fn() {
+main := fn() {
     // NOTE: constants not allowed
     let n = 3;
     let arr: [3]u32 = {1, 2, 3};

--- a/tests/array4.eve
+++ b/tests/array4.eve
@@ -1,9 +1,9 @@
 module hello;
 
-main :: fn() {
+main := fn() {
     bar({4, 6, 9, 4});
 }
 
-bar :: fn(x: [4]u32) {
+bar := fn(x: [4]u32) {
     dbg x;
 }

--- a/tests/array5.eve
+++ b/tests/array5.eve
@@ -1,6 +1,6 @@
 module hello;
 
-main :: fn() {
+main := fn() {
     let x: [3]u32 = {1, 2, 3};
     dbg x;
     x[0] = 69;

--- a/tests/array6.eve
+++ b/tests/array6.eve
@@ -1,13 +1,13 @@
 module hello;
 
-main :: fn() {
+main := fn() {
     let x: [_]u32 = {69, 420, 1337};
     dbg x;
     bar(x);
 }
 
 // Inferring here will throw an error
-bar :: fn(x: [3]u32) -> u32 {
+bar := fn(x: [3]u32) -> u32 {
     dbg x;
     return x[0];
 }

--- a/tests/array7.eve
+++ b/tests/array7.eve
@@ -1,13 +1,13 @@
 module hello;
 
-main :: fn() {
+main := fn() {
     let x: [_]u32 = {69, 420, 1337};
     dbg x;
     bar(x);
 }
 
 // Inferring here will throw an error
-bar :: fn(x: [_]u32) -> u32 {
+bar := fn(x: [_]u32) -> u32 {
     dbg x;
     return x[0];
 }

--- a/tests/array_default_init.eve
+++ b/tests/array_default_init.eve
@@ -2,7 +2,7 @@ module hello;
 
 import std::io;
 
-main :: fn() {
+main := fn() {
     let xs: [3]u32 = {};
     dbg xs[0];
     dbg xs[1];

--- a/tests/assignment.eve
+++ b/tests/assignment.eve
@@ -3,7 +3,7 @@ module hello;
 // Comment test
 // int main(void) { printf("Hello world!\n"); }
 
-main :: fn() {
+main := fn() {
     let x = 69;
     let y = 420;
     y = 1337;

--- a/tests/bool.eve
+++ b/tests/bool.eve
@@ -3,7 +3,7 @@ module hello;
 // Comment test
 // int main(void) { printf("Hello world!\n"); }
 
-main :: fn() {
+main := fn() {
     let b: bool = true;
     dbg b;
     let x = false;

--- a/tests/boolexpr.eve
+++ b/tests/boolexpr.eve
@@ -3,7 +3,7 @@ module hello;
 // Comment test
 // int main(void) { printf("Hello world!\n"); }
 
-main :: fn() {
+main := fn() {
     dbg true  && true;
     dbg true  && false;
     dbg false && true;

--- a/tests/boolexpr_enforce.eve
+++ b/tests/boolexpr_enforce.eve
@@ -3,6 +3,6 @@ module hello;
 // Comment test
 // int main(void) { printf("Hello world!\n"); }
 
-main :: fn() {
+main := fn() {
     dbg 1 && true;
 }

--- a/tests/break_continue.eve
+++ b/tests/break_continue.eve
@@ -3,7 +3,7 @@ module hello;
 // Comment test
 // int main(void) { printf("Hello world!\n"); }
 
-main :: fn() {
+main := fn() {
     let x = 10;
     while true {
         dbg x;

--- a/tests/cast.eve
+++ b/tests/cast.eve
@@ -1,10 +1,10 @@
 module hello;
 
-main :: fn() {
+main := fn() {
     let x: s32 = 69;
     foo(x as usize);
 }
 
-foo :: fn(u: usize) {
+foo := fn(u: usize) {
     dbg u;
 }

--- a/tests/comparison.eve
+++ b/tests/comparison.eve
@@ -1,6 +1,6 @@
 module hello;
 
-main :: fn() {
+main := fn() {
     dbg 10 > 1;
     dbg -1 < 10;
     dbg 10 > -1;

--- a/tests/constant_array.eve
+++ b/tests/constant_array.eve
@@ -2,7 +2,7 @@ module hello;
 
 import std::io;
 
-main :: fn() {
+main := fn() {
     let SIZE: usize := 3;
     let xs: [SIZE]u32 = {};
     dbg xs[0];

--- a/tests/dbg.eve
+++ b/tests/dbg.eve
@@ -1,6 +1,6 @@
 module main;
 
-main :: fn() {
+main := fn() {
     let x = 5;
     dbg x;
 }

--- a/tests/defer.eve
+++ b/tests/defer.eve
@@ -1,6 +1,6 @@
 module hello;
 
-main :: fn() {
+main := fn() {
     defer {
         dbg 1;
         dbg 2;

--- a/tests/defer_defer.eve
+++ b/tests/defer_defer.eve
@@ -1,6 +1,6 @@
 module hello;
 
-main :: fn() {
+main := fn() {
     defer defer dbg 420;
     dbg 69;
 }

--- a/tests/deref_and_assign.eve
+++ b/tests/deref_and_assign.eve
@@ -1,6 +1,6 @@
 module hello;
 
-main :: fn() {
+main := fn() {
     let x = 5;
     let y = &x;
     let z = *y;

--- a/tests/functions.eve
+++ b/tests/functions.eve
@@ -1,10 +1,10 @@
 module hello;
 
-main :: fn() {
+main := fn() {
     let i: s32 = add(34, 35);
     dbg i;
 }
 
-add :: fn(x: s32, y: s32) -> s32 {
+add := fn(x: s32, y: s32) -> s32 {
     return x + y;
 }

--- a/tests/hello_world.eve
+++ b/tests/hello_world.eve
@@ -1,7 +1,7 @@
 module hello;
 
-puts :: fn(text: cstr) #extern("puts");
+puts := fn(text: cstr) #extern("puts");
 
-main :: fn() {
+main := fn() {
     puts(c"Hello world");
 }

--- a/tests/if.eve
+++ b/tests/if.eve
@@ -1,6 +1,6 @@
 module hello;
 
-main :: fn() {
+main := fn() {
     if false then
     dbg 1;
     else {

--- a/tests/implicit.eve
+++ b/tests/implicit.eve
@@ -4,7 +4,7 @@ import std::io;
 import libc::io;
 import libc::mem;
 
-main :: fn() {
+main := fn() {
     let x: u32 = 69;
     let y: u64 = im x;
 }

--- a/tests/implicit2.eve
+++ b/tests/implicit2.eve
@@ -4,7 +4,7 @@ import std::io;
 import libc::io;
 import libc::mem;
 
-main :: fn() {
+main := fn() {
     uu64();
     ss64();
     uu32();
@@ -15,7 +15,7 @@ main :: fn() {
     ss8();
 }
 
-uu64 :: fn() {
+uu64 := fn() {
     let x: u64 = 69;
     let a: s64 = im x;
     let b: u32 = im x;
@@ -34,7 +34,7 @@ uu64 :: fn() {
     dbg 1000000001;
 }
 
-ss64 :: fn() {
+ss64 := fn() {
     let x: s64 = 69;
     let a: u64 = im x;
     let b: u32 = im x;
@@ -53,7 +53,7 @@ ss64 :: fn() {
     dbg 1000000001;
 }
 
-uu32 :: fn() {
+uu32 := fn() {
     let x: u32 = 69;
     let a: s32 = im x;
     let b: u64 = im x;
@@ -72,7 +72,7 @@ uu32 :: fn() {
     dbg 1000000001;
 }
 
-ss32 :: fn() {
+ss32 := fn() {
     let x: s32 = 69;
     let a: u32 = im x;
     let b: u64 = im x;
@@ -91,7 +91,7 @@ ss32 :: fn() {
     dbg 1000000001;
 }
 
-uu16 :: fn() {
+uu16 := fn() {
     let x: u16 = 69;
     let a: s16 = im x;
     let b: u64 = im x;
@@ -110,7 +110,7 @@ uu16 :: fn() {
     dbg 1000000001;
 }
 
-ss16 :: fn() {
+ss16 := fn() {
     let x: s16 = 69;
     let a: u16 = im x;
     let b: u64 = im x;
@@ -129,7 +129,7 @@ ss16 :: fn() {
     dbg 1000000001;
 }
 
-uu8 :: fn() {
+uu8 := fn() {
     let x: u8  = 69;
     let a: s8  = im x;
     let b: u64 = im x;
@@ -148,7 +148,7 @@ uu8 :: fn() {
     dbg 1000000001;
 }
 
-ss8 :: fn() {
+ss8 := fn() {
     let x: s8  = 69;
     let a: u8  = im x;
     let b: u64 = im x;

--- a/tests/inttypes.eve
+++ b/tests/inttypes.eve
@@ -1,6 +1,6 @@
 module hello;
 
-main :: fn() {
+main := fn() {
     let x: u64 = 9223372036854775807;
     dbg x;
     let y = x;

--- a/tests/malloc_free_and_voidptr.eve
+++ b/tests/malloc_free_and_voidptr.eve
@@ -2,7 +2,7 @@ module hello;
 
 import libc::mem;
 
-main :: fn() {
+main := fn() {
     let xs: [_]u32 = {1, 2, 3};
     let x = xs[..];
     let p: *[]u32 = mem::malloc(16);

--- a/tests/module.eve
+++ b/tests/module.eve
@@ -2,12 +2,12 @@ module hello;
 
 import foo;
 
-main :: fn() {
+main := fn() {
     foo();
     foo::foo();
     foo::add();
 }
 
-foo :: fn() {
+foo := fn() {
     dbg 69;
 }

--- a/tests/module2.eve
+++ b/tests/module2.eve
@@ -3,7 +3,7 @@ module hello;
 import std::mod;
 import std::io::mod;
 
-main :: fn() {
+main := fn() {
     io::mod::a();
     mod::b();
 }

--- a/tests/module2_io_mod.eve
+++ b/tests/module2_io_mod.eve
@@ -1,9 +1,9 @@
 module std::io::mod;
 
-a :: fn() {
+a := fn() {
     dbg 420;
 }
 
-b :: fn() {
+b := fn() {
     dbg 1337;
 }

--- a/tests/module2_mod.eve
+++ b/tests/module2_mod.eve
@@ -1,5 +1,5 @@
 module std::mod;
 
-b :: fn() {
+b := fn() {
     dbg 69;
 }

--- a/tests/module_foo.eve
+++ b/tests/module_foo.eve
@@ -1,10 +1,10 @@
 module foo;
 
-foo :: fn() {
+foo := fn() {
     dbg 1337;
 }
 
-add :: fn() {
+add := fn() {
     let x: u64 = 380;
     let y: u64 = 15 + 5;
     dbg x + y;

--- a/tests/nested_array_constant.eve
+++ b/tests/nested_array_constant.eve
@@ -2,7 +2,7 @@ module hello;
 
 import std::io;
 
-main :: fn() {
+main := fn() {
     let SIZE := 3;
     let xs: [1][SIZE]u32 = {{1, 2, 3}};
     dbg xs;

--- a/tests/nullptr.eve
+++ b/tests/nullptr.eve
@@ -1,6 +1,6 @@
 module hello;
 
-main :: fn() {
+main := fn() {
     let x = 5;
     let y: *s32 = null;
     dbg y;

--- a/tests/nullptr_equality.eve
+++ b/tests/nullptr_equality.eve
@@ -1,6 +1,6 @@
 module hello;
 
-main :: fn() {
+main := fn() {
     let n: u8 = 69;
     let buf: *u8 = &n;
     let p: *u8 = null;

--- a/tests/pointer_type_annotation.eve
+++ b/tests/pointer_type_annotation.eve
@@ -1,6 +1,6 @@
 module hello;
 
-main :: fn() {
+main := fn() {
     let x = 5;
     let y: *s32 = 5;
     let z = *y;

--- a/tests/ptr_functions.eve
+++ b/tests/ptr_functions.eve
@@ -1,6 +1,6 @@
 module hello;
 
-main :: fn() {
+main := fn() {
     // Dangerous!
     let y = bar();
     *y = 1337;
@@ -12,11 +12,11 @@ main :: fn() {
     // foo(null); SIGSEGV
 }
 
-foo :: fn(p: *s32) {
+foo := fn(p: *s32) {
     *p = 420;
 }
 
-bar :: fn() -> *s32 {
+bar := fn() -> *s32 {
     let x = 5;
     return &x;
 }

--- a/tests/redefinition.eve
+++ b/tests/redefinition.eve
@@ -3,7 +3,7 @@ module hello;
 // Comment test
 // int main(void) { printf("Hello world!\n"); }
 
-main :: fn() {
+main := fn() {
     let x = 69;
     let y = 420;
     let y = 1337;

--- a/tests/return_check.eve
+++ b/tests/return_check.eve
@@ -1,10 +1,10 @@
 module hello;
 
-main :: fn() {
+main := fn() {
     let x = bar();
 }
 
-bar :: fn() -> s32 {
+bar := fn() -> s32 {
     if (true) {
         return 69;
     }

--- a/tests/return_typecheck.eve
+++ b/tests/return_typecheck.eve
@@ -1,6 +1,6 @@
 module hello;
 
-main :: fn() {
+main := fn() {
     let z = 0;
     dbg succ(z);
     dbg succ(succ(z));
@@ -8,10 +8,10 @@ main :: fn() {
     dbg gt(69, 420);
 }
 
-succ :: fn(x: s32) -> s32 {
+succ := fn(x: s32) -> s32 {
     return x + 1;
 }
 
-gt :: fn(a: s32, b: s32) -> bool {
+gt := fn(a: s32, b: s32) -> bool {
     return 1;
 }

--- a/tests/rule110_stub.eve
+++ b/tests/rule110_stub.eve
@@ -2,7 +2,7 @@ module rule110;
 
 import std::io;
 
-check :: fn(tape: [3]u8, i: s32) {
+check := fn(tape: [3]u8, i: s32) {
     if tape[i] == 0 && tape[i+1] == 0 && tape[i+2] == 1 then io::println("1");
     else {
         dbg 420;
@@ -13,7 +13,7 @@ check :: fn(tape: [3]u8, i: s32) {
     }
 }
 
-main :: fn() {
+main := fn() {
     let tape: [3]u8 = {0, 0, 1};
     let i = 0;
     check(tape, i);

--- a/tests/slice_call_convention.eve
+++ b/tests/slice_call_convention.eve
@@ -1,12 +1,12 @@
 module hello;
 
-main :: fn() {
+main := fn() {
     let xs: [_]u32 = {1, 2, 3};
     let slc = xs[..];
     bar(slc);
 }
 
-bar :: fn(s: []u32) {
+bar := fn(s: []u32) {
     dbg s[0];
     dbg s[1];
     dbg s[2];

--- a/tests/slice_init_list.eve
+++ b/tests/slice_init_list.eve
@@ -2,7 +2,7 @@ module hello;
 
 import std::io;
 
-main :: fn() {
+main := fn() {
     let c: cstr = c"Hello!\n";
     let s: str = {c, 7};
     io::print(s);

--- a/tests/slice_methods.eve
+++ b/tests/slice_methods.eve
@@ -1,6 +1,6 @@
 module hello;
 
-main :: fn() {
+main := fn() {
     let x: [_]s32 = {1, 2};
     //dbg x[..].ptr();
     dbg x[..].len();

--- a/tests/slices1.eve
+++ b/tests/slices1.eve
@@ -1,6 +1,6 @@
 module hello;
 
-main :: fn() {
+main := fn() {
     let xs: [_]u32 = {1, 2, 3};
     let slc: []u32 = xs[..];
     dbg slc[0];
@@ -9,7 +9,7 @@ main :: fn() {
     bar(slc);
 }
 
-bar :: fn(x: []u32) {
+bar := fn(x: []u32) {
     dbg x[0];
     dbg x[1];
     dbg x[2];

--- a/tests/slices2.eve
+++ b/tests/slices2.eve
@@ -1,6 +1,6 @@
 module hello;
 
-main :: fn() {
+main := fn() {
     let xs: [_]u32 = {1, 2, 3};
     let slc1 = xs[..];
     let slc2 = xs[1..];

--- a/tests/slices3.eve
+++ b/tests/slices3.eve
@@ -1,6 +1,6 @@
 module hello;
 
-main :: fn() {
+main := fn() {
     let xs: [_]u32 = {1, 2, 3};
     let slc = xs[..];
     let slc2 = slc[..];

--- a/tests/slices4_abi.eve
+++ b/tests/slices4_abi.eve
@@ -1,12 +1,12 @@
 module hello;
 
-main :: fn() {
+main := fn() {
     let xs: [_]u32 = {1, 2, 3};
     let slc = slice(xs);
     dbg slc[0] + slc[1] + slc[2];
 }
 
-slice :: fn(xs: [3]u32) -> []u32 {
+slice := fn(xs: [3]u32) -> []u32 {
     let slc = xs[..];
     return slc;
 }

--- a/tests/stackframe1.eve
+++ b/tests/stackframe1.eve
@@ -3,7 +3,7 @@ module hello;
 // Comment test
 // int main(void) { printf("Hello world!\n"); }
 
-main :: fn() {
+main := fn() {
     let x = 69;
     dbg x;
 
@@ -14,11 +14,11 @@ main :: fn() {
 }
 
 
-foo :: fn() {
+foo := fn() {
     if true then dbg 69;
 }
 
-bar :: fn() {
+bar := fn() {
     if false {
         dbg 420;
     } else if 69 == 69 {

--- a/tests/stackframe2.eve
+++ b/tests/stackframe2.eve
@@ -1,6 +1,6 @@
 module hello;
 
-main :: fn() {
+main := fn() {
     let x = 69;
     dbg x;
 
@@ -11,11 +11,11 @@ main :: fn() {
 }
 
 
-foo :: fn() {
+foo := fn() {
     if true then dbg 69;
 }
 
-bar :: fn() {
+bar := fn() {
     if false {
         dbg 420;
     } else if 69 == 69 {

--- a/tests/string_escaping.eve
+++ b/tests/string_escaping.eve
@@ -3,7 +3,7 @@ module hello;
 import std::io;
 import libc::io;
 
-main :: fn() {
+main := fn() {
     std::io::print("Hello from std io!\n");
     std::io::print("This is also a new line!\x0A");
     libc::io::puts(c"This C string is cut off early! \0 You can't read this!");

--- a/tests/strings.eve
+++ b/tests/strings.eve
@@ -1,6 +1,6 @@
 module hello;
 
-main :: fn() {
+main := fn() {
     let x: str = "hello world";
     dbg x[5];
 

--- a/tests/struct_pointer.eve
+++ b/tests/struct_pointer.eve
@@ -1,11 +1,11 @@
 module hello;
 
-main :: fn() {
+main := fn() {
     let xs: [_]u32 = {1, 2, 3};
     let struct: []u32 = xs[..];
     foo(&struct);
 }
 
-foo :: fn(ptr: *[]u32) {
+foo := fn(ptr: *[]u32) {
     dbg (*ptr)[2];
 }

--- a/tests/type_alias1.eve
+++ b/tests/type_alias1.eve
@@ -3,7 +3,7 @@ module hello;
 type str2 = []u8;
 type cstr2 = *u8;
 
-main :: fn() {
+main := fn() {
     let xs: [_]u8 = {69, 420};
     let slc: str2 = xs[..];
     foo(slc);
@@ -11,6 +11,6 @@ main :: fn() {
     let c: cstr2 = &x;
 }
 
-foo :: fn(xs: str2) {
+foo := fn(xs: str2) {
     // nothing for now
 }

--- a/tests/type_alias2_redef.eve
+++ b/tests/type_alias2_redef.eve
@@ -4,7 +4,7 @@ type str2 = []u8;
 type cstr2 = *u8;
 type str2 = bool;
 
-main :: fn() {
+main := fn() {
     let xs: [_]u8 = {1, 2};
     let slc: str2 = xs[..];
     foo(xs[..]);
@@ -13,6 +13,6 @@ main :: fn() {
     dbg c;
 }
 
-foo :: fn(xs: []u8) {
+foo := fn(xs: []u8) {
     dbg xs[1];
 }

--- a/tests/type_printing.eve
+++ b/tests/type_printing.eve
@@ -1,11 +1,11 @@
 module hello;
 
-main :: fn() {
+main := fn() {
     let x = 5;
     let y = &x;
     dbg y;
 }
 
-foo :: fn() -> s32 {
+foo := fn() -> s32 {
     return true;
 }

--- a/tests/usize.eve
+++ b/tests/usize.eve
@@ -1,6 +1,6 @@
 module hello;
 
-main :: fn() {
+main := fn() {
     let y: usize = 69;
     dbg y;
 }

--- a/tests/while.eve
+++ b/tests/while.eve
@@ -1,6 +1,6 @@
 module hello;
 
-main :: fn() {
+main := fn() {
     let x = 10;
     while x >= 0 {
         dbg x;


### PR DESCRIPTION
This is consistent with local constants that now use the `:=` operator to avoid a parsing ambiguity.